### PR TITLE
Fix title pill glow color

### DIFF
--- a/static/css/sonic_titles.css
+++ b/static/css/sonic_titles.css
@@ -13,7 +13,8 @@
   font-size: 1.15rem;
   font-weight: 600;
   border-radius: 50px;
-  box-shadow: inset 0 0 5px #ffa726;
+  /* Soften the glow with a bluish tone instead of the original yellow */
+  box-shadow: inset 0 0 5px #80c5d1;
   background-size: cover;
   background-repeat: no-repeat;
   background-position: center;


### PR DESCRIPTION
## Summary
- switch the `sonic-title-pill` inset shadow from yellow to blue

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pydantic')*