### PR TITLE
Refactor hedge report layout

### DIFF
--- a/static/css/hedge_report.css
+++ b/static/css/hedge_report.css
@@ -66,32 +66,9 @@ th.sorted-desc .sort-indicator { color: var(--primary); }
   font-style: italic;
 }
 
-/* Container for both tables so they sit flush */
-.dual-table-wrapper {
-  display: flex;
-  width: 100%;
-  gap: 0;
-}
-
-.dual-table-wrapper .positions-table-wrapper {
-  flex: 1 1 0;
-  width: auto;
-}
-
-/* Make the first table wider to prevent crowding */
-.dual-table-wrapper .positions-table-wrapper:first-child {
-  flex-basis: 60%;
-}
-
-.dual-table-wrapper .positions-table-wrapper:last-child {
-  flex-basis: 40%;
-}
-
-/* Expand the main panel to use the full section width */
-.hedge-report-panel {
-  max-width: none;
-  width: 100%;
-}
+/* Previously used container for both tables */
+/* .dual-table-wrapper and .hedge-report-panel were removed in favor of */
+/* individual content panels matching the dashboard layout. */
 
 /* Outer borders for tables */
 #short-table {

--- a/templates/hedge_report.html
+++ b/templates/hedge_report.html
@@ -22,11 +22,10 @@
 <!-- Page Title Removed -->
 
 <div class="sonic-section-container sonic-section-middle mt-3">
-  <div class="sonic-content-panel hedge-report-panel">
-    <div class="dual-table-wrapper">
-      <div class="positions-table-wrapper">
-        <h3 class="section-title icon-inline text-center mb-2"><span>📉</span><span>SHORT</span></h3>
-        <table id="short-table" class="positions-table">
+  <div class="sonic-content-panel">
+    <div class="positions-table-wrapper">
+      <h3 class="section-title icon-inline text-center mb-2"><span>📉</span><span>SHORT</span></h3>
+      <table id="short-table" class="positions-table">
           <thead>
             <tr>
               <th class="sortable left" data-col-index="0">Asset <span class="sort-indicator"></span></th>
@@ -93,10 +92,12 @@
             </tr>
           </tfoot>
         </table>
-      </div>
-      <div class="positions-table-wrapper">
-        <h3 class="section-title icon-inline text-center mb-2"><span>📈</span><span>LONG</span></h3>
-        <table id="long-table" class="positions-table">
+    </div>
+  </div>
+  <div class="sonic-content-panel">
+    <div class="positions-table-wrapper">
+      <h3 class="section-title icon-inline text-center mb-2"><span>📈</span><span>LONG</span></h3>
+      <table id="long-table" class="positions-table">
           <thead>
             <tr>
               <th class="sortable center size-col" data-col-index="0">Size <span class="sort-indicator"></span></th>
@@ -163,7 +164,6 @@
             </tr>
           </tfoot>
         </table>
-      </div>
     </div>
   </div>
 </div>


### PR DESCRIPTION
## Summary
- adopt dashboard style layout for hedge report
- remove old dual table wrapper rules

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pydantic')*