### PR TITLE
Unify hedge report tables

### DIFF
--- a/static/css/hedge_report.css
+++ b/static/css/hedge_report.css
@@ -66,9 +66,19 @@ th.sorted-desc .sort-indicator { color: var(--primary); }
   font-style: italic;
 }
 
-/* Previously used container for both tables */
-/* .dual-table-wrapper and .hedge-report-panel were removed in favor of */
-/* individual content panels matching the dashboard layout. */
+/* Container when short and long tables share a single panel */
+.hedge-report-panel {
+  max-width: 100%;
+}
+
+.dual-table-wrapper {
+  display: flex;
+  width: 100%;
+}
+
+.dual-table-wrapper .positions-table-wrapper {
+  flex: 1 1 0;
+}
 
 /* Outer borders for tables */
 #short-table {

--- a/templates/hedge_report.html
+++ b/templates/hedge_report.html
@@ -22,8 +22,9 @@
 <!-- Page Title Removed -->
 
 <div class="sonic-section-container sonic-section-middle mt-3">
-  <div class="sonic-content-panel">
-    <div class="positions-table-wrapper">
+  <div class="sonic-content-panel hedge-report-panel">
+    <div class="dual-table-wrapper">
+      <div class="positions-table-wrapper">
       <h3 class="section-title icon-inline text-center mb-2"><span>📉</span><span>SHORT</span></h3>
       <table id="short-table" class="positions-table">
           <thead>
@@ -92,10 +93,8 @@
             </tr>
           </tfoot>
         </table>
-    </div>
-  </div>
-  <div class="sonic-content-panel">
-    <div class="positions-table-wrapper">
+      </div>
+      <div class="positions-table-wrapper">
       <h3 class="section-title icon-inline text-center mb-2"><span>📈</span><span>LONG</span></h3>
       <table id="long-table" class="positions-table">
           <thead>
@@ -164,6 +163,7 @@
             </tr>
           </tfoot>
         </table>
+      </div>
     </div>
   </div>
 </div>


### PR DESCRIPTION
## Summary
- show short and long tables in one panel on Hedge Report
- add styles for the new dual-table layout

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pydantic')*