### PR TITLE
Fix slider row width

### DIFF
--- a/templates/hedge_calculator_results.html
+++ b/templates/hedge_calculator_results.html
@@ -2,7 +2,7 @@
 <!-- Rows 4-6 from hedge_calculator.html -->
 <div id="projectedOutputRow" class="row mb-4">
   <!-- Price slider removed -->
-  <div class="col-md-6 slider-box mb-3">
+  <div class="col-md-12 slider-box mb-3">
     <label for="leverageSlider" class="form-label"><strong>Projected Leverage</strong></label>
     <input type="range" class="form-range" id="leverageSlider" min="1" max="20" step="0.1">
     <div id="leverageValue" class="mt-2">Leverage: 1x</div>


### PR DESCRIPTION
## Summary
- tweak the Hedge Calculator top row to use full width

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'pydantic')*