### PR TITLE
Add AutoCore phantom workflow

### DIFF
--- a/auto_core/__init__.py
+++ b/auto_core/__init__.py
@@ -1,0 +1,4 @@
+from .auto_core import AutoCore
+from . import phantom_workflow
+
+__all__ = ["AutoCore", "phantom_workflow"]

--- a/auto_core/auto_core.py
+++ b/auto_core/auto_core.py
@@ -1,0 +1,60 @@
+"""Automated collateral management via the Jupiter UI."""
+
+from playwright.sync_api import sync_playwright
+
+from . import phantom_workflow as pwf
+
+
+class AutoCore:
+    """High level workflows using Playwright and Phantom."""
+
+    def __init__(self, phantom_path: str, profile_dir: str, headless: bool = False) -> None:
+        self.phantom_path = phantom_path
+        self.profile_dir = profile_dir
+        self.headless = headless
+
+    # ------------------------------------------------------------------
+    def _launch_context(self):
+        pw = sync_playwright().start()
+        context = pw.chromium.launch_persistent_context(
+            self.profile_dir,
+            channel="chromium",
+            headless=self.headless,
+            args=[
+                f"--disable-extensions-except={self.phantom_path}",
+                f"--load-extension={self.phantom_path}",
+            ],
+        )
+        page = context.new_page()
+        page.goto("https://jup.ag/perpetuals")
+        return pw, context, page
+
+    def _close(self, pw, context):
+        context.close()
+        pw.stop()
+
+    # ------------------------------------------------------------------
+    def deposit_collateral(self, amount: float) -> None:
+        """Automate collateral deposit via the UI."""
+        pw, ctx, page = self._launch_context()
+        try:
+            pwf.connect_wallet(page)
+            page.fill("input[type=number]", str(amount))
+            page.click("button:has-text('Deposit')")
+            pwf.approve_popup(page)
+            pwf.confirm_transaction(page)
+        finally:
+            self._close(pw, ctx)
+
+    def withdraw_collateral(self, amount: float) -> None:
+        """Automate collateral withdrawal via the UI."""
+        pw, ctx, page = self._launch_context()
+        try:
+            pwf.connect_wallet(page)
+            page.fill("input[type=number]", str(amount))
+            page.click("button:has-text('Withdraw')")
+            pwf.approve_popup(page)
+            pwf.confirm_transaction(page)
+        finally:
+            self._close(pw, ctx)
+

--- a/auto_core/phantom_workflow.py
+++ b/auto_core/phantom_workflow.py
@@ -1,0 +1,33 @@
+"""Helper workflow for Phantom wallet automation via Playwright.
+
+Selectors and workflow steps follow the collateral automation white paper
+located at ``sonic_labs/collateral_management_playwright_white_paper.md``.
+"""
+
+from playwright.sync_api import Page
+
+
+def connect_wallet(page: Page) -> None:
+    """Connect Phantom wallet on Jupiter using the connect popup."""
+    # Click the connect button on Jupiter
+    page.click("button:has-text('Connect')")
+    popup = page.context.wait_for_event("page")
+    wallet_page = popup.value if hasattr(popup, "value") else popup
+    wallet_page.wait_for_selector("button:has-text('Connect')")
+    wallet_page.click("button:has-text('Connect')")
+    wallet_page.close()
+
+
+def approve_popup(page: Page) -> None:
+    """Approve a Phantom confirmation popup."""
+    popup = page.context.wait_for_event("page")
+    p = popup.value if hasattr(popup, "value") else popup
+    p.wait_for_selector("button:has-text('Approve')")
+    p.click("button:has-text('Approve')")
+    p.close()
+
+
+def confirm_transaction(page: Page, timeout: int = 30_000) -> None:
+    """Wait for Jupiter UI to display a transaction confirmation."""
+    page.wait_for_selector("text=Transaction confirmed", timeout=timeout)
+


### PR DESCRIPTION
## Summary
- add phantom wallet automation helpers in `auto_core`
- implement `AutoCore` class with deposit/withdraw workflows
- expose `AutoCore` via package init
- rely on Jupiter Phantom workflow from automation white paper

## Testing
- `pytest tests/test_jupiter_service.py -q`