### PR TITLE
Add debug flag to logging config

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,18 @@ Or execute the full test suite using:
 pytest
 ```
 
+### Debug Logging
+
+To see verbose output from the console logger, pass `debug=True` when
+configuring logging:
+
+```python
+from core.logging import configure_console_log
+configure_console_log(debug=True)
+```
+
+Classes like `Cyclone` propagate this flag via their own `debug` parameter.
+
 ## Twilio Testing
 
 To verify your Twilio credentials or trigger a Studio Flow, copy `.env.example` to

--- a/core/logging.py
+++ b/core/logging.py
@@ -2,6 +2,7 @@
 
 import sys
 import os
+import logging
 from utils.rich_logger import RichLogger
 
 log = RichLogger()
@@ -9,8 +10,15 @@ log = RichLogger()
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 
 
-def configure_console_log():
-    """🧠 Cyclone Logging Configuration"""
+def configure_console_log(debug: bool = False):
+    """🧠 Cyclone Logging Configuration
+
+    Parameters
+    ----------
+    debug : bool, optional
+        If ``True`` the root logger level is set to ``logging.DEBUG`` to
+        output verbose diagnostic information. Defaults to ``False``.
+    """
     log.hijack_logger("werkzeug")
     log.silence_module("werkzeug")
     # log.silence_module("fuzzy_wuzzy")
@@ -46,3 +54,7 @@ def configure_console_log():
     ]:
         log.silence_module(module)
     log.init_status()
+
+    if debug:
+        log.logger.setLevel(logging.DEBUG)
+

--- a/cyclone/cyclone_engine.py
+++ b/cyclone/cyclone_engine.py
@@ -10,7 +10,7 @@ import traceback  # PATCH: for full stack info
 from alert_core.alert_core import AlertCore #alert_service_manager import AlertServiceManager
 from data.data_locker import DataLocker
 from core.constants import DB_PATH, ALERT_LIMITS_PATH
-from core.logging import log
+from core.logging import log, configure_console_log
 
 # PATCH: Import SystemCore for death screams
 from system.system_core import SystemCore
@@ -28,11 +28,15 @@ from hedge_core.hedge_core import HedgeCore
 
 global_data_locker = DataLocker(str(DB_PATH))  # There can be only one
 
-def configure_cyclone_console_log():
+def configure_cyclone_console_log(debug: bool = False):
+    """Centralized Cyclone Console Log Config
+
+    Parameters
+    ----------
+    debug : bool, optional
+        When ``True`` the underlying logger is configured for verbose output.
     """
-    🧠 Centralized Cyclone Console Log Config
-    Enables all core modules for debugging.
-    """
+    configure_console_log(debug=debug)
     log.silence_module("werkzeug")
     log.silence_module("fuzzy_wuzzy")
 
@@ -65,11 +69,14 @@ def configure_cyclone_console_log():
 
 
 class Cyclone:
-    def __init__(self, monitor_core=None, poll_interval=60):
-        configure_cyclone_console_log()
+    def __init__(self, monitor_core=None, poll_interval=60, debug: bool = False):
+        configure_cyclone_console_log(debug=debug)
         self.logger = logging.getLogger("Cyclone")
         self.poll_interval = poll_interval
-        self.logger.setLevel(logging.DEBUG)
+        if debug:
+            self.logger.setLevel(logging.DEBUG)
+        else:
+            self.logger.setLevel(logging.INFO)
         self.monitor_core = monitor_core or MonitorCore()
 
         self.data_locker = global_data_locker

--- a/cyclone_app.py
+++ b/cyclone_app.py
@@ -10,10 +10,10 @@ from core.core_imports import configure_console_log, DB_PATH
 from data.data_locker import DataLocker
 
 console = Console()
-configure_console_log()
+configure_console_log(debug=True)
 dl = DataLocker(str(DB_PATH))
 monitor_core = MonitorCore()
-cyclone = Cyclone(monitor_core)
+cyclone = Cyclone(monitor_core, debug=True)
 
 
 def get_counts_banner():

--- a/sonic_app.py
+++ b/sonic_app.py
@@ -50,7 +50,7 @@ from cyclone.cyclone_engine import Cyclone
 # --- Logging Setup ---
 log.banner("SONIC DASHBOARD STARTUP")
 log.enable_all()
-configure_console_log()
+configure_console_log(debug=True)
 
 # --- Flask Setup ---
 app = Flask(__name__)
@@ -62,7 +62,7 @@ socketio = SocketIO(app)
 app.data_locker = DataLocker(str(DB_PATH))
 app.system_core = SystemCore(app.data_locker)
 app.monitor_core = MonitorCore()
-app.cyclone = Cyclone(monitor_core=app.monitor_core)
+app.cyclone = Cyclone(monitor_core=app.monitor_core, debug=True)
 
 # --- Blueprints ---
 from app.positions_bp import positions_bp


### PR DESCRIPTION
## Summary
- support debug mode in `configure_console_log`
- propagate debug option in Cyclone engine and callers
- update CLI scripts to opt into verbose logs
- document debug usage in README

## Testing
- `pytest -q` *(fails: Alert() takes no arguments)*