### PR TITLE
Integrate ChatGPT blueprint

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,3 +8,5 @@ TWILIO_FROM_PHONE=+1987654321
 TWILIO_TO_PHONE=+1234567890
 # Optional Jupiter endpoint override
 JUPITER_API_BASE=https://perps-api.jup.ag
+# OpenAI API key for ChatGPT integration
+OPEN_AI_KEY=your_openai_key_here

--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ TWILIO_TO_PHONE=+1234567890
 # Optional
 TWILIO_FLOW_SID=your_flow_sid_here
 JUPITER_API_BASE=https://perps-api.jup.ag
+OPEN_AI_KEY=your_openai_key_here
 ```
 
 `JUPITER_API_BASE` lets you override the default Jupiter endpoint if it changes.

--- a/gpt/chat_gpt_bp.py
+++ b/gpt/chat_gpt_bp.py
@@ -1,0 +1,61 @@
+import os
+import logging
+from flask import Blueprint, render_template, request, jsonify
+from openai import OpenAI
+from dotenv import load_dotenv
+
+# Load environment variables from .env if present
+load_dotenv()
+
+logger = logging.getLogger("ChatGPTBP")
+logger.setLevel(logging.DEBUG)
+
+# Instantiate the OpenAI client using API key from env
+client = OpenAI(api_key=os.getenv("OPEN_AI_KEY"))
+
+chat_gpt_bp = Blueprint(
+    "chat_gpt_bp",
+    __name__,
+    url_prefix="/GPT",
+    template_folder="templates",
+)
+
+@chat_gpt_bp.route("/chat", methods=["GET"])
+def chat():
+    """Render the ChatGPT interface."""
+    logger.debug("GET /chat - Rendering chat interface.")
+    return render_template("chat_gpt.html")
+
+
+@chat_gpt_bp.route("/chat", methods=["POST"])
+def chat_post():
+    """Handle ChatGPT messages and return the response."""
+    logger.debug("POST /chat - Received request.")
+    data = request.get_json() or {}
+    logger.debug(f"Request JSON: {data}")
+    user_message = (data.get("message") or "").strip()
+    logger.debug(f"User message: '{user_message}'")
+
+    if not user_message:
+        logger.debug("No valid message provided; returning error response.")
+        return jsonify({"reply": "Please provide a valid message."}), 400
+
+    messages = [
+        {"role": "system", "content": "You are a helpful assistant."},
+        {"role": "user", "content": user_message},
+    ]
+    logger.debug(f"Sending messages to OpenAI: {messages}")
+
+    try:
+        response = client.chat.completions.create(
+            model="gpt-3.5-turbo",
+            messages=messages,
+        )
+        logger.debug("Received response from OpenAI API.")
+        reply = response.choices[0].message.content.strip()
+        logger.debug(f"ChatGPT reply: '{reply}'")
+        return jsonify({"reply": reply})
+    except Exception as e:  # pragma: no cover - rely on OpenAI client
+        logger.exception(f"OpenAI API error: {e}")
+        return jsonify({"reply": f"An error occurred: {e}"}), 500
+

--- a/sonic_app.py
+++ b/sonic_app.py
@@ -75,6 +75,7 @@ from cyclone.cyclone_bp import cyclone_bp
 from routes.theme_routes import theme_bp
 from app.system_bp import system_bp
 from settings.settings_bp import settings_bp
+from gpt.chat_gpt_bp import chat_gpt_bp
 
 log.info("Registering blueprints...", source="Startup")
 app.register_blueprint(positions_bp, url_prefix="/positions")
@@ -87,6 +88,7 @@ app.register_blueprint(cyclone_bp)
 app.register_blueprint(theme_bp)
 app.register_blueprint(system_bp)
 app.register_blueprint(settings_bp)
+app.register_blueprint(chat_gpt_bp)
 
 # --- Set Default Email Provider for XCom ---
 with app.app_context():

--- a/templates/chat_gpt.html
+++ b/templates/chat_gpt.html
@@ -1,0 +1,41 @@
+{% extends "base.html" %}
+{% block title %}ChatGPT{% endblock %}
+
+{% block extra_styles %}
+{{ super() }}
+<link rel="stylesheet" href="{{ url_for('static', filename='css/title_bar.css') }}">
+<link rel="stylesheet" href="{{ url_for('static', filename='css/sonic_themes.css') }}">
+<link rel="stylesheet" href="{{ url_for('static', filename='css/sonic_titles.css') }}">
+{% endblock %}
+
+{% block content %}
+{% set title_text = 'ChatGPT' %}
+{% include "title_bar.html" %}
+<div class="container py-4">
+  <div class="mb-3">
+    <label for="messageInput" class="form-label">Message</label>
+    <input type="text" id="messageInput" class="form-control">
+  </div>
+  <button id="sendBtn" class="btn btn-primary">Send</button>
+  <pre id="responseDisplay" class="mt-3"></pre>
+</div>
+{% endblock %}
+
+{% block extra_scripts %}
+{{ super() }}
+<script src="{{ url_for('static', filename='js/title_bar.js') }}" defer></script>
+<script>
+  document.getElementById('sendBtn').addEventListener('click', async () => {
+    const msg = document.getElementById('messageInput').value.trim();
+    if (!msg) return;
+    const res = await fetch('{{ url_for('chat_gpt_bp.chat_post') }}', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ message: msg })
+    });
+    const data = await res.json();
+    document.getElementById('responseDisplay').textContent = data.reply;
+  });
+</script>
+{% endblock %}
+


### PR DESCRIPTION
## Summary
- create `/GPT` blueprint for ChatGPT interactions
- add a simple frontend template for ChatGPT
- register the blueprint in `sonic_app.py`
- document `OPEN_AI_KEY` in README and `.env.example`

## Testing
- `pytest -q`