### PR TITLE
Rename env variable for OpenAI

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,4 +9,4 @@ TWILIO_TO_PHONE=+1234567890
 # Optional Jupiter endpoint override
 JUPITER_API_BASE=https://perps-api.jup.ag
 # OpenAI API key for ChatGPT integration
-OPEN_AI_KEY=your_openai_key_here
+OPENAI_API_KEY=your_openai_key_here

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ TWILIO_TO_PHONE=+1234567890
 # Optional
 TWILIO_FLOW_SID=your_flow_sid_here
 JUPITER_API_BASE=https://perps-api.jup.ag
-OPEN_AI_KEY=your_openai_key_here
+OPENAI_API_KEY=your_openai_key_here
 ```
 
 `JUPITER_API_BASE` lets you override the default Jupiter endpoint if it changes.

--- a/gpt/chat_gpt_bp.py
+++ b/gpt/chat_gpt_bp.py
@@ -10,8 +10,12 @@ load_dotenv()
 logger = logging.getLogger("ChatGPTBP")
 logger.setLevel(logging.DEBUG)
 
-# Instantiate the OpenAI client using API key from env
-client = OpenAI(api_key=os.getenv("OPEN_AI_KEY"))
+# Instantiate the OpenAI client using API key from env.
+# Prefer the new ``OPENAI_API_KEY`` variable but fall back to ``OPEN_AI_KEY``
+# for backward compatibility.
+client = OpenAI(
+    api_key=os.getenv("OPENAI_API_KEY") or os.getenv("OPEN_AI_KEY")
+)
 
 chat_gpt_bp = Blueprint(
     "chat_gpt_bp",


### PR DESCRIPTION
## Summary
- rename `OPEN_AI_KEY` to `OPENAI_API_KEY`
- adjust docs and example env file
- fall back to old var name for backwards compatibility

## Testing
- `pytest -q`