### PR TITLE
Add OPEN_AI_KEY requirement

### DIFF
--- a/tests/test_startup_service_env.py
+++ b/tests/test_startup_service_env.py
@@ -1,0 +1,26 @@
+import os
+import importlib
+import pytest
+
+from utils import startup_service as ss
+
+
+def test_startup_fails_without_open_ai_key(monkeypatch):
+    # Reload module to ensure environment variables are checked with our settings
+    importlib.reload(ss)
+    required = [
+        "SMTP_SERVER",
+        "SMTP_PORT",
+        "SMTP_USERNAME",
+        "SMTP_PASSWORD",
+        "SMTP_DEFAULT_RECIPIENT",
+        "TWILIO_ACCOUNT_SID",
+        "TWILIO_AUTH_TOKEN",
+        "TWILIO_FROM_PHONE",
+        "TWILIO_TO_PHONE",
+    ]
+    for var in required:
+        monkeypatch.setenv(var, "1")
+    monkeypatch.delenv("OPEN_AI_KEY", raising=False)
+    with pytest.raises(SystemExit):
+        ss.StartUpService.check_env_vars()

--- a/utils/startup_service.py
+++ b/utils/startup_service.py
@@ -192,6 +192,7 @@ class StartUpService:
             "TWILIO_AUTH_TOKEN",
             "TWILIO_FROM_PHONE",
             "TWILIO_TO_PHONE",
+            "OPEN_AI_KEY",
         ]
         missing = [var for var in required if not os.getenv(var)]
         if missing:


### PR DESCRIPTION
## Summary
- check OPEN_AI_KEY in startup environment validation
- test startup fails when OPEN_AI_KEY is missing

## Testing
- `pytest -q`