### PR TITLE
Rename OPEN_AI_KEY to OPENAI_API_KEY

### DIFF
--- a/tests/test_startup_service_env.py
+++ b/tests/test_startup_service_env.py
@@ -5,7 +5,7 @@ import pytest
 from utils import startup_service as ss
 
 
-def test_startup_fails_without_open_ai_key(monkeypatch):
+def test_startup_fails_without_openai_api_key(monkeypatch):
     # Reload module to ensure environment variables are checked with our settings
     importlib.reload(ss)
     required = [
@@ -21,6 +21,7 @@ def test_startup_fails_without_open_ai_key(monkeypatch):
     ]
     for var in required:
         monkeypatch.setenv(var, "1")
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
     monkeypatch.delenv("OPEN_AI_KEY", raising=False)
     with pytest.raises(SystemExit):
         ss.StartUpService.check_env_vars()

--- a/utils/startup_service.py
+++ b/utils/startup_service.py
@@ -192,9 +192,12 @@ class StartUpService:
             "TWILIO_AUTH_TOKEN",
             "TWILIO_FROM_PHONE",
             "TWILIO_TO_PHONE",
-            "OPEN_AI_KEY",
         ]
+
         missing = [var for var in required if not os.getenv(var)]
+
+        if not (os.getenv("OPENAI_API_KEY") or os.getenv("OPEN_AI_KEY")):
+            missing.append("OPENAI_API_KEY")
         if missing:
             log.critical("❌ Missing required environment variables:")
             for var in missing:


### PR DESCRIPTION
## Summary
- update StartUpService to look for `OPENAI_API_KEY`
- keep backward compatibility with `OPEN_AI_KEY`
- adjust startup service env test to use new variable

## Testing
- `pytest tests/test_startup_service_env.py -q`
- `pytest -k startup_service_env -q`