### PR TITLE
Strip OpenAI API key whitespace

### DIFF
--- a/gpt/chat_gpt_bp.py
+++ b/gpt/chat_gpt_bp.py
@@ -13,9 +13,8 @@ logger.setLevel(logging.DEBUG)
 # Instantiate the OpenAI client using API key from env.
 # Prefer the new ``OPENAI_API_KEY`` variable but fall back to ``OPEN_AI_KEY``
 # for backward compatibility.
-client = OpenAI(
-    api_key=os.getenv("OPENAI_API_KEY") or os.getenv("OPEN_AI_KEY")
-)
+api_key = (os.getenv("OPENAI_API_KEY") or os.getenv("OPEN_AI_KEY") or "").strip()
+client = OpenAI(api_key=api_key)
 
 chat_gpt_bp = Blueprint(
     "chat_gpt_bp",


### PR DESCRIPTION
## Summary
- trim whitespace from OPENAI API key when creating the OpenAI client

## Testing
- `pytest -q`