### PR TITLE
Update ChatGPT page with model and token info

### DIFF
--- a/gpt/chat_gpt_bp.py
+++ b/gpt/chat_gpt_bp.py
@@ -16,6 +16,9 @@ logger.setLevel(logging.DEBUG)
 api_key = (os.getenv("OPENAI_API_KEY") or os.getenv("OPEN_AI_KEY") or "").strip()
 client = OpenAI(api_key=api_key)
 
+# Default model used for chat completions.
+MODEL_NAME = "gpt-3.5-turbo"
+
 chat_gpt_bp = Blueprint(
     "chat_gpt_bp",
     __name__,
@@ -27,7 +30,7 @@ chat_gpt_bp = Blueprint(
 def chat():
     """Render the ChatGPT interface."""
     logger.debug("GET /chat - Rendering chat interface.")
-    return render_template("chat_gpt.html")
+    return render_template("chat_gpt.html", model_name=MODEL_NAME)
 
 
 @chat_gpt_bp.route("/chat", methods=["POST"])
@@ -51,13 +54,20 @@ def chat_post():
 
     try:
         response = client.chat.completions.create(
-            model="gpt-3.5-turbo",
+            model=MODEL_NAME,
             messages=messages,
         )
         logger.debug("Received response from OpenAI API.")
         reply = response.choices[0].message.content.strip()
         logger.debug(f"ChatGPT reply: '{reply}'")
-        return jsonify({"reply": reply})
+
+        usage = {}
+        try:
+            usage = response.usage.model_dump() if response.usage else {}
+        except Exception as ex:  # pragma: no cover - defensive
+            logger.debug(f"Usage parsing failed: {ex}")
+
+        return jsonify({"reply": reply, "model": response.model, "usage": usage})
     except Exception as e:  # pragma: no cover - rely on OpenAI client
         logger.exception("OpenAI API error")
         return jsonify({"reply": f"An error occurred: {e}"}), 500

--- a/templates/chat_gpt.html
+++ b/templates/chat_gpt.html
@@ -84,6 +84,12 @@
 <div class="chat-container">
 
   <h1>ChatGPT Interface</h1>
+
+  <div id="infoPanel" style="margin-bottom: 1rem;">
+    <p>Model: {{ model_name }}</p>
+    <p id="tokenInfo"></p>
+  </div>
+
   <div class="chat-window" id="chatWindow">
     <!-- Chat messages will appear here -->
   </div>
@@ -102,6 +108,7 @@
 const sendBtn = document.getElementById('sendBtn');
 const userInput = document.getElementById('userInput');
 const chatWindow = document.getElementById('chatWindow');
+const tokenInfo = document.getElementById('tokenInfo');
 
 function addMessage(content, sender) {
   const div = document.createElement('div');
@@ -126,6 +133,9 @@ sendBtn.addEventListener('click', async () => {
     if (!res.ok) throw new Error('Network response was not ok');
     const data = await res.json();
     addMessage(data.reply, 'bot');
+    if (data.usage) {
+      tokenInfo.textContent = `Prompt tokens: ${data.usage.prompt_tokens}, Completion tokens: ${data.usage.completion_tokens}, Total: ${data.usage.total_tokens}`;
+    }
   } catch (err) {
     console.error('Error:', err);
     addMessage('Oops, something went wrong. Please try again.', 'bot');


### PR DESCRIPTION
## Summary
- display active model name in ChatGPT page
- return token usage from OpenAI responses
- show latest token usage in UI

## Testing
- `pytest -q`