### PR TITLE
Add GPT Input Specification

### DIFF
--- a/FULL_SPEC.md
+++ b/FULL_SPEC.md
@@ -35,6 +35,9 @@ The [Wallet Core specification](wallets/wallet_core_spec.md) outlines wallet ope
 ### Auto Core
 The [Auto Core module](auto_core/auto_core_module_spec.md) automates collateral actions in the Jupiter UI using Playwright and Phantom.
 
+### GPT Input Format
+The [GPT Input specification](gpt_input_spec.md) details the JSON bundle used to send portfolio and alert context to GPT for analysis.
+
 ---
 
 Each linked specification contains more detailed design notes, functional requirements, and example workflows.

--- a/SPECIFICATIONS.md
+++ b/SPECIFICATIONS.md
@@ -33,6 +33,9 @@ The [Monitor module](monitor/monitor_module_spec.md) drives periodic tasks and h
 ### Wallets
 The [Wallet Core specification](wallets/wallet_core_spec.md) outlines wallet operations and blockchain helpers. The [Jupiter API spec](wallets/jupiter_api_spec.md) from **sonic_labs** describes how wallets interact with Jupiter Perps for managing collateral.
 
+### GPT Input Format
+The [GPT Input specification](gpt_input_spec.md) details the JSON bundle used to send portfolio and alert context to GPT for analysis.
+
 ---
 
 Each linked specification contains more detailed design notes, functional requirements, and example workflows.

--- a/gpt_input_spec.md
+++ b/gpt_input_spec.md
@@ -1,0 +1,28 @@
+# 📘 GPT Input Specification — Modular Portfolio Analysis
+**Version:** 1.0  
+**Generated:** 2025-05-26 20:08:36  
+**Author:** Geno
+
+---
+
+## 🎯 Purpose
+This specification defines the modular JSON format for sending portfolio, alert, and analysis context to GPT. It allows structured evaluation of risk, hedging, and performance.
+
+---
+
+## 🧩 Top-Level File: `gpt_response_wrapper.json`
+Acts as the main bundle reference.
+```json
+{
+  "type": "gpt_analysis_bundle",
+  "version": "1.0",
+  "generated": "YYYY-MM-DDTHH:MM:SSZ",
+  "meta_file": "gpt_meta_input.json",
+  "definitions_file": "gpt_definitions_input.json",
+  "alert_limits_file": "gpt_alert_limits_input.json",
+  "module_reference_file": "gpt_module_references.json",
+  "current_snapshot_file": "snapshot_<DATE>.json",
+  "previous_snapshot_file": "snapshot_<DATE>.json",
+  "instructions_for_ai": "Prompt for GPT's use"
+}
+```


### PR DESCRIPTION
## Summary
- document the modular GPT input format
- link GPT docs in SPECIFICATIONS and FULL_SPEC

## Testing
- `pytest -q`