### PR TITLE
Add ChatGPT context support

### DIFF
--- a/gpt/__init__.py
+++ b/gpt/__init__.py
@@ -1,0 +1,1 @@
+from .context_loader import get_context_messages

--- a/gpt/chat_gpt_bp.py
+++ b/gpt/chat_gpt_bp.py
@@ -4,6 +4,8 @@ from flask import Blueprint, render_template, request, jsonify
 from openai import OpenAI
 from dotenv import load_dotenv
 
+from .context_loader import get_context_messages
+
 # Load environment variables from .env if present
 load_dotenv()
 
@@ -46,10 +48,9 @@ def chat_post():
         logger.debug("No valid message provided; returning error response.")
         return jsonify({"reply": "Please provide a valid message."}), 400
 
-    messages = [
-        {"role": "system", "content": "You are a helpful assistant."},
-        {"role": "user", "content": user_message},
-    ]
+    messages = [{"role": "system", "content": "You are a helpful assistant."}]
+    messages.extend(get_context_messages())
+    messages.append({"role": "user", "content": user_message})
     logger.debug(f"Sending messages to OpenAI: {messages}")
 
     try:

--- a/gpt/context_loader.py
+++ b/gpt/context_loader.py
@@ -1,0 +1,46 @@
+import json
+import logging
+import os
+
+logger = logging.getLogger(__name__)
+
+DATA_DIR = os.path.join(os.path.dirname(__file__), "data")
+
+
+def _load_json(name: str) -> dict:
+    """Load a JSON file from the data directory."""
+    path = os.path.join(DATA_DIR, name)
+    if not os.path.exists(path):
+        logger.debug("Context file missing: %s", path)
+        return {}
+    try:
+        with open(path, "r", encoding="utf-8") as f:
+            return json.load(f)
+    except Exception as ex:  # pragma: no cover - defensive
+        logger.error("Failed to load %s: %s", name, ex)
+        return {}
+
+
+def get_context_data() -> dict:
+    """Return dict of loaded context files by name."""
+    files = [
+        "gpt_meta_input.json",
+        "gpt_definitions_input.json",
+        "gpt_alert_limits_input.json",
+        "gpt_module_references.json",
+        "snapshot_sample.json",
+    ]
+    data = {}
+    for fname in files:
+        content = _load_json(fname)
+        if content:
+            data[fname] = content
+    return data
+
+
+def get_context_messages() -> list:
+    """Return a list of system messages for ChatGPT."""
+    messages = []
+    for content in get_context_data().values():
+        messages.append({"role": "system", "content": json.dumps(content)})
+    return messages

--- a/gpt/data/gpt_alert_limits_input.json
+++ b/gpt/data/gpt_alert_limits_input.json
@@ -1,0 +1,10 @@
+{
+  "alert_ranges": {
+    "heat_index_ranges": {
+      "enabled": true,
+      "low": 7.0,
+      "medium": 33.0,
+      "high": 66.0
+    }
+  }
+}

--- a/gpt/data/gpt_definitions_input.json
+++ b/gpt/data/gpt_definitions_input.json
@@ -1,0 +1,7 @@
+{
+  "type": "definitions",
+  "metrics": {
+    "travel_percent": "Defines change from entry to current price",
+    "heat_index": "Composite risk metric"
+  }
+}

--- a/gpt/data/gpt_meta_input.json
+++ b/gpt/data/gpt_meta_input.json
@@ -1,0 +1,8 @@
+{
+  "type": "meta",
+  "version": "1.0",
+  "owner": "Geno",
+  "strategy": "hedged, automated trading",
+  "goal": "optimize exposure while minimizing risk",
+  "notes": "Background context"
+}

--- a/gpt/data/gpt_module_references.json
+++ b/gpt/data/gpt_module_references.json
@@ -1,0 +1,10 @@
+{
+  "modules": {
+    "PositionCore": {
+      "role": "Manages enrichment, snapshots, sync"
+    },
+    "HedgeCalcServices": {
+      "role": "Suggests hedge rebalancing"
+    }
+  }
+}

--- a/gpt/data/snapshot_sample.json
+++ b/gpt/data/snapshot_sample.json
@@ -1,0 +1,11 @@
+{
+  "positions": [
+    {
+      "id": "sample",
+      "asset_type": "BTC",
+      "position_type": "LONG",
+      "leverage": 5.0,
+      "travel_percent": -12.4
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- include new GPT context loader
- feed context data to ChatGPT blueprint
- store example context files for meta info, definitions, alert ranges, module references and a sample snapshot

## Testing
- `pytest -q`