### PR TITLE
Switch value calculations to collateral + PnL

### DIFF
--- a/FULL_SPEC.md
+++ b/FULL_SPEC.md
@@ -1543,7 +1543,7 @@ Logs count if needed
 
 ⚙️ CalcServices (Used by Enrichment)
 Method	Purpose
-calculate_value()	size × price
+calculate_value()       collateral + P&L
 calculate_leverage()	value ÷ collateral
 calculate_travel_percent()	price deviation vs liquidation
 calculate_liquid_distance()	dollar or % distance

--- a/positions/position_module_spec.md
+++ b/positions/position_module_spec.md
@@ -209,7 +209,7 @@ Logs count if needed
 
 ⚙️ CalcServices (Used by Enrichment)
 Method	Purpose
-calculate_value()	size × price
+calculate_value()       collateral + P&L
 calculate_leverage()	value ÷ collateral
 calculate_travel_percent()	price deviation vs liquidation
 calculate_liquid_distance()	dollar or % distance

--- a/tests/test_calc_services_at_price.py
+++ b/tests/test_calc_services_at_price.py
@@ -7,8 +7,8 @@ def sample_position():
         "position_type": "LONG",
         "entry_price": 100.0,
         "liquidation_price": 50.0,
-        # Size represents token amount. Entry price is 100, so position value at
-        # entry is 200 and leverage matches collateral below.
+        # Size represents token amount. Entry price is 100, collateral is 100.
+        # Value is calculated as collateral plus P&L.
         "size": 2.0,
         "collateral": 100.0,
         "leverage": 2.0,
@@ -17,7 +17,7 @@ def sample_position():
 def test_price_metric_functions(sample_position):
     calc = CalcServices()
     price = 90.0
-    assert calc.value_at_price(sample_position, price) == pytest.approx(180.0)
+    assert calc.value_at_price(sample_position, price) == pytest.approx(99.8)
     assert calc.travel_percent_at_price(sample_position, price) == pytest.approx(-20.0)
     assert calc.liquid_distance_at_price(sample_position, price) == 40.0
     # Collateral is high relative to size so risk floor of 5 applies
@@ -27,7 +27,7 @@ def test_evaluate_at_price(sample_position):
     calc = CalcServices()
     price = 120.0
     result = calc.evaluate_at_price(sample_position, price)
-    assert result["value"] == pytest.approx(240.0)
+    assert result["value"] == pytest.approx(100.4)
     assert result["travel_percent"] == pytest.approx(40.0)
     assert result["liquidation_distance"] == 70.0
     assert result["heat_index"] == pytest.approx(5.0)


### PR DESCRIPTION
## Summary
- compute position value as collateral plus profit/loss
- adapt value_at_price helper accordingly
- update CalcServices docs and specs
- adjust CalcServices tests for new definition

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pydantic')*