### PR TITLE
Add self-contained ChatGPT API test script

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,21 @@ The script loads credentials from the `.env` file (or environment variables) and
 uses `scripts/twilio_test.py` to perform the authentication and optional flow
 execution.
 
+## ChatGPT API Test
+
+To verify your OpenAI credentials, copy `.env.example` to `.env`, fill in your
+`OPENAI_API_KEY`, and run:
+
+```bash
+python scripts/openai_test.py
+```
+
+The script automatically loads environment variables from `.env` (with
+`.env.example` as a fallback).
+
+The script sends a simple prompt to ChatGPT and prints the response. It exits
+with status code `0` on success and `1` on failure.
+
 ## Required Environment Variables
 
 The application expects several environment variables for email and Twilio

--- a/scripts/openai_test.py
+++ b/scripts/openai_test.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python3
+"""Simple script to verify OpenAI ChatGPT API access.
+
+This script sends a test prompt to the ChatGPT API using the ``openai``
+package. Provide the API key via the ``--key`` argument or the
+``OPENAI_API_KEY`` (preferred) or ``OPEN_AI_KEY`` environment variables.
+The script prints the response from ChatGPT and exits with status 0 on
+success or 1 on failure.
+"""
+
+import argparse
+import os
+import sys
+from pathlib import Path
+from typing import Optional
+
+try:
+    from dotenv import load_dotenv
+except Exception:  # pragma: no cover - optional dependency
+    def load_dotenv(*_a, **_k):
+        return False
+
+__test__ = False
+
+try:
+    from openai import OpenAI
+except Exception:  # pragma: no cover - optional dependency
+    OpenAI = None
+
+
+def call_chatgpt(api_key: str, prompt: str) -> int:
+    """Send ``prompt`` to ChatGPT using ``api_key`` and return an exit code."""
+    if OpenAI is None:
+        print("openai package not available")
+        return 1
+
+    try:
+        client = OpenAI(api_key=api_key)
+        response = client.chat.completions.create(
+            model="gpt-3.5-turbo",
+            messages=[{"role": "user", "content": prompt}],
+        )
+        print("✅ API call succeeded")
+        print(response.choices[0].message.content.strip())
+        return 0
+    except Exception as exc:  # pragma: no cover - network dependent
+        print("❌ API call failed")
+        print(str(exc))
+        return 1
+
+
+def main(argv: Optional[list[str]] = None) -> int:
+    parser = argparse.ArgumentParser(description="Test ChatGPT API access")
+    parser.add_argument(
+        "--key",
+        help=(
+            "OpenAI API key (defaults to OPENAI_API_KEY or OPEN_AI_KEY environment" 
+            " variables)"
+        ),
+    )
+    parser.add_argument(
+        "--prompt", default="Say hello", help="Prompt text to send to ChatGPT"
+    )
+    args = parser.parse_args(argv)
+
+    # Load environment variables from project .env files
+    base_dir = Path(__file__).resolve().parent.parent
+    load_dotenv(base_dir / ".env")
+    load_dotenv(base_dir / ".env.example")
+
+    api_key = args.key or os.getenv("OPENAI_API_KEY") or os.getenv("OPEN_AI_KEY")
+    if not api_key:
+        print("OPENAI_API_KEY or OPEN_AI_KEY is required")
+        return 1
+
+    return call_chatgpt(api_key, args.prompt)
+
+
+if __name__ == "__main__":
+    sys.exit(main())
+


### PR DESCRIPTION
## Summary
- add `scripts/openai_test.py` for verifying ChatGPT API credentials
- document usage of new script in README
- load environment variables from `.env`

## Testing
- `pytest -q`
- `python scripts/openai_test.py` *(fails: OPENAI_API_KEY or OPEN_AI_KEY is required)*