### PR TITLE
Implement GPT context service

### DIFF
--- a/gpt/__init__.py
+++ b/gpt/__init__.py
@@ -3,6 +3,7 @@ from .context_loader import get_context_messages
 from .chat_gpt_bp import chat_gpt_bp
 from .gpt_bp import gpt_bp
 from .gpt_core import GPTCore
+from .create_gpt_context_service import create_gpt_context_service
 
-__all__ = ["chat_gpt_bp", "gpt_bp", "GPTCore"]
+__all__ = ["chat_gpt_bp", "gpt_bp", "GPTCore", "create_gpt_context_service"]
 

--- a/gpt/create_gpt_context_service.py
+++ b/gpt/create_gpt_context_service.py
@@ -1,0 +1,34 @@
+import json
+from typing import List
+
+from .context_loader import get_context_messages
+
+
+def create_gpt_context_service(core, request_type: str, instructions: str = "") -> List[dict]:
+    """Return chat messages for GPT based on the request type.
+
+    Parameters
+    ----------
+    core : object
+        Instance providing ``build_payload`` for analysis requests.
+    request_type : str
+        Type of request, e.g. ``"analysis"`` or ``"portfolio"``.
+    instructions : str, optional
+        Optional instructions for GPT.
+    """
+    if request_type == "analysis":
+        payload = core.build_payload(instructions)
+        return [
+            {"role": "system", "content": "You are a portfolio analysis assistant."},
+            {"role": "user", "content": json.dumps(payload)},
+        ]
+
+    if request_type == "portfolio":
+        messages = [
+            {"role": "system", "content": "You are a portfolio analysis assistant."}
+        ]
+        messages.extend(get_context_messages())
+        messages.append({"role": "user", "content": instructions or "Provide a portfolio analysis summary."})
+        return messages
+
+    raise ValueError(f"Unsupported request type: {request_type}")

--- a/gpt/gpt_core.py
+++ b/gpt/gpt_core.py
@@ -10,6 +10,7 @@ from openai import OpenAI
 
 from data.data_locker import DataLocker
 from core.constants import DB_PATH
+from .create_gpt_context_service import create_gpt_context_service
 
 
 class GPTCore:
@@ -71,12 +72,8 @@ class GPTCore:
         return payload
 
     def analyze(self, instructions: str = "") -> str:
-        payload = self.build_payload(instructions)
-        self.logger.debug("Sending payload to GPT")
-        messages = [
-            {"role": "system", "content": "You are a portfolio analysis assistant."},
-            {"role": "user", "content": json.dumps(payload)},
-        ]
+        self.logger.debug("Preparing analysis context for GPT")
+        messages = create_gpt_context_service(self, "analysis", instructions)
         try:
             response = self.client.chat.completions.create(
                 model="gpt-3.5-turbo", messages=messages
@@ -90,12 +87,8 @@ class GPTCore:
 
     def ask_gpt_about_portfolio(self) -> str:
         """Use standard JSON context files to query GPT about the portfolio."""
-        from .context_loader import get_context_messages
-
-        self.logger.debug("Sending standard context files to GPT")
-        messages = [{"role": "system", "content": "You are a portfolio analysis assistant."}]
-        messages.extend(get_context_messages())
-        messages.append({"role": "user", "content": "Provide a portfolio analysis summary."})
+        self.logger.debug("Preparing portfolio context for GPT")
+        messages = create_gpt_context_service(self, "portfolio", "Provide a portfolio analysis summary.")
         try:
             response = self.client.chat.completions.create(
                 model="gpt-3.5-turbo", messages=messages

--- a/tests/test_gpt_context_service.py
+++ b/tests/test_gpt_context_service.py
@@ -1,0 +1,56 @@
+import json
+import importlib.util
+from pathlib import Path
+import types
+import sys
+
+
+class DummyCore:
+    def build_payload(self, instructions: str = "") -> dict:
+        return {"test": True, "instructions_for_ai": instructions or "default"}
+
+
+def load_module():
+    base = Path(__file__).resolve().parents[1] / "gpt"
+    # Create dummy gpt package
+    pkg = types.ModuleType("gpt")
+    sys.modules.setdefault("gpt", pkg)
+
+    ctx_path = base / "context_loader.py"
+    ctx_spec = importlib.util.spec_from_file_location("gpt.context_loader", ctx_path)
+    ctx_mod = importlib.util.module_from_spec(ctx_spec)
+    assert ctx_spec and ctx_spec.loader
+    ctx_spec.loader.exec_module(ctx_mod)
+    sys.modules["gpt.context_loader"] = ctx_mod
+    setattr(pkg, "context_loader", ctx_mod)
+
+    path = base / "create_gpt_context_service.py"
+    spec = importlib.util.spec_from_file_location("gpt.create_gpt_context_service", path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec and spec.loader
+    spec.loader.exec_module(module)
+    sys.modules["gpt.create_gpt_context_service"] = module
+    return module
+
+
+def test_create_analysis_context(monkeypatch):
+    mod = load_module()
+    core = DummyCore()
+    messages = mod.create_gpt_context_service(core, "analysis", "inspect")
+    assert messages[0]["role"] == "system"
+    payload = json.loads(messages[1]["content"])
+    assert payload["test"] is True
+    assert payload["instructions_for_ai"] == "inspect"
+
+
+def test_create_portfolio_context(monkeypatch):
+    mod = load_module()
+    core = DummyCore()
+
+    def fake_context_messages():
+        return [{"role": "system", "content": "ctx"}]
+
+    monkeypatch.setattr(mod, "get_context_messages", fake_context_messages)
+    messages = mod.create_gpt_context_service(core, "portfolio", "summary")
+    assert messages[0]["role"] == "system"
+    assert messages[-1]["content"] == "summary"


### PR DESCRIPTION
## Summary
- create `create_gpt_context_service` for assembling ChatGPT messages
- use new service in `GPTCore` for both analysis and portfolio queries
- expose the service from the `gpt` package
- test the context service logic

## Testing
- `pytest -k gpt_context_service -q`
- `pytest -q`