### PR TITLE
Implement GPT portfolio inquiry

### DIFF
--- a/gpt/gpt_bp.py
+++ b/gpt/gpt_bp.py
@@ -16,3 +16,11 @@ def analyze():
     core = GPTCore()
     result = core.analyze(instructions)
     return jsonify({"reply": result})
+
+
+@gpt_bp.route('/gpt/portfolio', methods=['GET'])
+def ask_portfolio():
+    """Return GPT analysis using standard context files."""
+    core = GPTCore()
+    result = core.ask_gpt_about_portfolio()
+    return jsonify({"reply": result})

--- a/gpt/gpt_core.py
+++ b/gpt/gpt_core.py
@@ -1,6 +1,7 @@
 
 import json
 import logging
+import os
 from datetime import datetime
 from typing import Any, Dict, Optional
 
@@ -85,5 +86,24 @@ class GPTCore:
             return reply
         except Exception as e:  # pragma: no cover - depends on OpenAI API
             self.logger.exception(f"GPT analysis failed: {e}")
+            return f"Error: {e}"
+
+    def ask_gpt_about_portfolio(self) -> str:
+        """Use standard JSON context files to query GPT about the portfolio."""
+        from .context_loader import get_context_messages
+
+        self.logger.debug("Sending standard context files to GPT")
+        messages = [{"role": "system", "content": "You are a portfolio analysis assistant."}]
+        messages.extend(get_context_messages())
+        messages.append({"role": "user", "content": "Provide a portfolio analysis summary."})
+        try:
+            response = self.client.chat.completions.create(
+                model="gpt-3.5-turbo", messages=messages
+            )
+            reply = response.choices[0].message.content.strip()
+            self.logger.debug("Received portfolio reply from GPT")
+            return reply
+        except Exception as e:  # pragma: no cover - depends on OpenAI API
+            self.logger.exception(f"GPT portfolio query failed: {e}")
             return f"Error: {e}"
 

--- a/templates/chat_gpt.html
+++ b/templates/chat_gpt.html
@@ -75,6 +75,21 @@
   .input-area button:hover {
     background-color: #0056b3;
   }
+
+  .oracle-panel {
+    max-width: 800px;
+    margin: 2rem auto;
+    padding: 1rem;
+  }
+
+  .oracle-output {
+    min-height: 120px;
+    border: 1px solid #ddd;
+    border-radius: 5px;
+    padding: 0.5rem;
+    background: #fafafa;
+    white-space: pre-wrap;
+  }
 </style>
 {% endblock %}
 
@@ -98,6 +113,17 @@
     <button id="sendBtn">Send</button>
   </div>
 </div>
+
+<div class="oracle-panel sonic-content-panel mt-4">
+  <div class="section-title icon-inline"><span>🧙</span><span>The Oracle</span></div>
+  <div class="oracle-btns d-flex justify-content-around mb-3">
+    <button class="oracle-btn btn btn-outline-primary" data-topic="portfolio" title="Ask about portfolio">📂</button>
+    <button class="oracle-btn btn btn-outline-secondary" data-topic="alerts" title="Ask about alerts">🚨</button>
+    <button class="oracle-btn btn btn-outline-secondary" data-topic="prices" title="Ask about prices">💲</button>
+    <button class="oracle-btn btn btn-outline-secondary" data-topic="system" title="Ask about system">🖥️</button>
+  </div>
+  <div id="oracleOutput" class="oracle-output"></div>
+</div>
 {% endblock %}
 
 {% block extra_scripts %}
@@ -109,6 +135,25 @@ const sendBtn = document.getElementById('sendBtn');
 const userInput = document.getElementById('userInput');
 const chatWindow = document.getElementById('chatWindow');
 const tokenInfo = document.getElementById('tokenInfo');
+const oracleOutput = document.getElementById('oracleOutput');
+document.querySelectorAll('.oracle-btn').forEach(btn => {
+  btn.addEventListener('click', async () => {
+    const topic = btn.dataset.topic;
+    if (topic !== 'portfolio') {
+      oracleOutput.textContent = 'Coming soon...';
+      return;
+    }
+    try {
+      const res = await fetch('{{ url_for('gpt_bp.ask_portfolio') }}');
+      if (!res.ok) throw new Error('Network response was not ok');
+      const data = await res.json();
+      oracleOutput.textContent = data.reply;
+    } catch (err) {
+      console.error('Error:', err);
+      oracleOutput.textContent = 'Oops, something went wrong. Please try again.';
+    }
+  });
+});
 
 function addMessage(content, sender) {
   const div = document.createElement('div');


### PR DESCRIPTION
## Summary
- add `ask_gpt_about_portfolio` to GPT core
- expose new `/gpt/portfolio` API endpoint
- extend chat UI with "The Oracle" panel for preset GPT topics

## Testing
- `pytest -q`
