### PR TITLE
Add oracle endpoints and layout tweaks for ChatGPT UI

### DIFF
--- a/gpt/gpt_bp.py
+++ b/gpt/gpt_bp.py
@@ -24,3 +24,20 @@ def ask_portfolio():
     core = GPTCore()
     result = core.ask_gpt_about_portfolio()
     return jsonify({"reply": result})
+
+
+@gpt_bp.route('/gpt/oracle/<topic>', methods=['GET'])
+def oracle(topic: str):
+    """Handle oracle queries for various topics."""
+    core = GPTCore()
+    if topic == 'portfolio':
+        result = core.ask_gpt_about_portfolio()
+    elif topic == 'alerts':
+        result = core.ask_gpt_about_alerts()
+    elif topic == 'prices':
+        result = core.ask_gpt_about_prices()
+    elif topic == 'system':
+        result = core.ask_gpt_about_system()
+    else:
+        return jsonify({"error": "Unknown topic"}), 400
+    return jsonify({"reply": result})

--- a/gpt/gpt_core.py
+++ b/gpt/gpt_core.py
@@ -108,3 +108,54 @@ class GPTCore:
             self.logger.exception(f"GPT portfolio query failed: {e}")
             return f"Error: {e}"
 
+    def ask_gpt_about_alerts(self) -> str:
+        """Summarize alert data using GPT."""
+        alerts = self.data_locker.alerts.get_all_alerts()[:20]
+        messages = [
+            {"role": "system", "content": "You summarize alert information."},
+            {"role": "system", "content": json.dumps({"alerts": alerts})},
+            {"role": "user", "content": "Provide a short summary of current alerts."},
+        ]
+        try:
+            response = self.client.chat.completions.create(
+                model="gpt-3.5-turbo", messages=messages
+            )
+            return response.choices[0].message.content.strip()
+        except Exception as e:  # pragma: no cover - depends on OpenAI API
+            self.logger.exception(f"GPT alerts query failed: {e}")
+            return f"Error: {e}"
+
+    def ask_gpt_about_prices(self) -> str:
+        """Summarize price data using GPT."""
+        prices = self.data_locker.prices.get_all_prices()[:20]
+        messages = [
+            {"role": "system", "content": "You summarize price information."},
+            {"role": "system", "content": json.dumps({"prices": prices})},
+            {"role": "user", "content": "Give a brief market overview."},
+        ]
+        try:
+            response = self.client.chat.completions.create(
+                model="gpt-3.5-turbo", messages=messages
+            )
+            return response.choices[0].message.content.strip()
+        except Exception as e:  # pragma: no cover - depends on OpenAI API
+            self.logger.exception(f"GPT prices query failed: {e}")
+            return f"Error: {e}"
+
+    def ask_gpt_about_system(self) -> str:
+        """Summarize system status using GPT."""
+        system = self.data_locker.get_last_update_times().to_dict()
+        messages = [
+            {"role": "system", "content": "You report system status."},
+            {"role": "system", "content": json.dumps(system)},
+            {"role": "user", "content": "Summarize the system health."},
+        ]
+        try:
+            response = self.client.chat.completions.create(
+                model="gpt-3.5-turbo", messages=messages
+            )
+            return response.choices[0].message.content.strip()
+        except Exception as e:  # pragma: no cover - depends on OpenAI API
+            self.logger.exception(f"GPT system query failed: {e}")
+            return f"Error: {e}"
+

--- a/templates/chat_gpt.html
+++ b/templates/chat_gpt.html
@@ -8,6 +8,7 @@
 <link rel="stylesheet" href="{{ url_for('static', filename='css/title_bar.css') }}">
 <link rel="stylesheet" href="{{ url_for('static', filename='css/sonic_themes.css') }}">
 <link rel="stylesheet" href="{{ url_for('static', filename='css/sonic_titles.css') }}">
+<link rel="stylesheet" href="{{ url_for('static', filename='css/sonic_dashboard.css') }}">
 <style>
 
   body {
@@ -17,14 +18,28 @@
     padding: 0;
   }
 
-  .chat-container {
-    max-width: 800px;
+  .chat-oracle-wrapper {
+    display: flex;
+    justify-content: center;
+    align-items: flex-start;
+    gap: 1rem;
+    max-width: 1200px;
     margin: 2rem auto;
+  }
+
+  .chat-container,
+  .oracle-panel {
+    flex: 1 1 0;
+    max-width: 550px;
     background-color: #fff;
     border: 1px solid #ddd;
     border-radius: 5px;
     padding: 1rem;
     box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+  }
+
+  .chat-container {
+    max-width: 700px;
   }
   .chat-window {
     height: 400px;
@@ -77,9 +92,7 @@
   }
 
   .oracle-panel {
-    max-width: 800px;
-    margin: 2rem auto;
-    padding: 1rem;
+    margin: 0;
   }
 
   .oracle-output {
@@ -96,34 +109,35 @@
 {% block content %}
 {% set title_text = 'ChatGPT' %}
 {% include "title_bar.html" %}
-<div class="chat-container">
-
-  <h1>ChatGPT Interface</h1>
-
-  <div id="infoPanel" style="margin-bottom: 1rem;">
-    <p>Model: {{ model_name }}</p>
-    <p id="tokenInfo"></p>
+<div class="chat-oracle-wrapper sonic-section-container">
+  <div class="oracle-panel sonic-content-panel">
+    <div class="section-title icon-inline"><span>🧙</span><span>The Oracle</span></div>
+    <div class="oracle-btns d-flex justify-content-around mb-3">
+      <button class="oracle-btn btn btn-outline-primary" data-topic="portfolio" title="Ask about portfolio">📂</button>
+      <button class="oracle-btn btn btn-outline-secondary" data-topic="alerts" title="Ask about alerts">🚨</button>
+      <button class="oracle-btn btn btn-outline-secondary" data-topic="prices" title="Ask about prices">💲</button>
+      <button class="oracle-btn btn btn-outline-secondary" data-topic="system" title="Ask about system">🖥️</button>
+    </div>
+    <div id="oracleOutput" class="oracle-output"></div>
   </div>
 
-  <div class="chat-window" id="chatWindow">
-    <!-- Chat messages will appear here -->
-  </div>
-  <div class="input-area">
-    <input type="text" id="userInput" placeholder="Type your message here..." />
-    <button id="sendBtn">Send</button>
-    <button id="portfolioBtn">Ask Portfolio</button>
-  </div>
-</div>
+  <div class="chat-container sonic-content-panel">
+    <h1>ChatGPT Interface</h1>
 
-<div class="oracle-panel sonic-content-panel mt-4">
-  <div class="section-title icon-inline"><span>🧙</span><span>The Oracle</span></div>
-  <div class="oracle-btns d-flex justify-content-around mb-3">
-    <button class="oracle-btn btn btn-outline-primary" data-topic="portfolio" title="Ask about portfolio">📂</button>
-    <button class="oracle-btn btn btn-outline-secondary" data-topic="alerts" title="Ask about alerts">🚨</button>
-    <button class="oracle-btn btn btn-outline-secondary" data-topic="prices" title="Ask about prices">💲</button>
-    <button class="oracle-btn btn btn-outline-secondary" data-topic="system" title="Ask about system">🖥️</button>
+    <div id="infoPanel" style="margin-bottom: 1rem;">
+      <p>Model: {{ model_name }}</p>
+      <p id="tokenInfo"></p>
+    </div>
+
+    <div class="chat-window" id="chatWindow">
+      <!-- Chat messages will appear here -->
+    </div>
+    <div class="input-area">
+      <input type="text" id="userInput" placeholder="Type your message here..." />
+      <button id="sendBtn">Send</button>
+      <button id="portfolioBtn">Ask Portfolio</button>
+    </div>
   </div>
-  <div id="oracleOutput" class="oracle-output"></div>
 </div>
 {% endblock %}
 
@@ -137,15 +151,13 @@ const userInput = document.getElementById('userInput');
 const chatWindow = document.getElementById('chatWindow');
 const tokenInfo = document.getElementById('tokenInfo');
 const oracleOutput = document.getElementById('oracleOutput');
+const oracleBase = "{{ url_for('gpt_bp.oracle', topic='') }}";
 document.querySelectorAll('.oracle-btn').forEach(btn => {
   btn.addEventListener('click', async () => {
     const topic = btn.dataset.topic;
-    if (topic !== 'portfolio') {
-      oracleOutput.textContent = 'Coming soon...';
-      return;
-    }
+    oracleOutput.textContent = '...';
     try {
-      const res = await fetch('{{ url_for('gpt_bp.ask_portfolio') }}');
+      const res = await fetch(oracleBase + topic);
       if (!res.ok) throw new Error('Network response was not ok');
       const data = await res.json();
       oracleOutput.textContent = data.reply;
@@ -196,7 +208,7 @@ userInput.addEventListener('keypress', e => {
 
 portfolioBtn.addEventListener('click', async () => {
   try {
-    const res = await fetch('{{ url_for('gpt_bp.ask_portfolio') }}');
+    const res = await fetch(oracleBase + 'portfolio');
     if (!res.ok) throw new Error('Network response was not ok');
     const data = await res.json();
     addMessage(data.reply, 'bot');
@@ -207,5 +219,7 @@ portfolioBtn.addEventListener('click', async () => {
 });
 
 </script>
+<script src="{{ url_for('static', filename='js/layout_mode.js') }}"></script>
+<script src="{{ url_for('static', filename='js/sonic_theme_toggle.js') }}"></script>
 {% endblock %}
 


### PR DESCRIPTION
## Summary
- add Oracle endpoints for alerts, prices and system data
- update GPT core with helper methods for new oracle topics
- arrange ChatGPT UI with an Oracle panel to the left of the chat window
- enable theme and layout toggles on the chat page

## Testing
- `pytest -q`