### PR TITLE
Add clickable dashboard link

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,9 @@ This installs `pytest` and all other required packages. Run the app with:
 ```bash
 python launch_app.py
 ```
+When the server starts, the console prints a clickable link to
+`http://127.0.0.1:5000/` (in terminals that support hyperlinks) so you can open
+the dashboard directly.
 
 The `.flaskenv` file provides the usual Flask environment variables for
 development. `PYTHONPATH` now points to the project root:
@@ -144,10 +147,7 @@ your shell) and then run:
 python sonic_app.py
 ```
 
-By default the server listens on `0.0.0.0:5000`. Open
-`http://127.0.0.1:5000/` in your browser to access the dashboard. Use the
-`--monitor` flag if you want to also launch the local monitor process in a
-separate console.
+By default the server listens on `0.0.0.0:5000`. The startup message prints a clickable link to `http://127.0.0.1:5000/` (when your terminal supports ANSI hyperlinks). Use the `--monitor` flag to also launch the local monitor process in a separate console.
 
 
 ## Initializing the Database

--- a/launch_app.py
+++ b/launch_app.py
@@ -41,6 +41,7 @@ def launch_sonic_web():
     console.print("[bold green]Launching Sonic Web...[/bold green]")
     proc = subprocess.Popen([sys.executable, "sonic_app.py"])
     time.sleep(2)
+    log.print_dashboard_link(host="127.0.0.1", port=5000, route="/")
     webbrowser.open("http://127.0.0.1:5000")
     try:
         proc.wait()
@@ -64,6 +65,7 @@ def launch_web_and_monitor():
     web_proc = subprocess.Popen([sys.executable, "sonic_app.py"])
     monitor_proc = subprocess.Popen([sys.executable, os.path.join("monitor", "sonic_monitor.py")])
     time.sleep(2)
+    log.print_dashboard_link(host="127.0.0.1", port=5000, route="/")
     webbrowser.open("http://127.0.0.1:5000")
     try:
         web_proc.wait()


### PR DESCRIPTION
## Summary
- log dashboard link when launching the web server
- document new clickable link when running `launch_app.py` and `sonic_app.py`

## Testing
- `pytest -q`