### PR TITLE
Add Oracle GPT interface

### DIFF
--- a/gpt/chat_gpt_bp.py
+++ b/gpt/chat_gpt_bp.py
@@ -35,6 +35,13 @@ def chat():
     return render_template("chat_gpt.html", model_name=MODEL_NAME)
 
 
+@chat_gpt_bp.route("/oracle", methods=["GET"])
+def oracle_ui():
+    """Render the GPT Oracle interface."""
+    logger.debug("GET /oracle - Rendering oracle interface.")
+    return render_template("oracle_gpt.html", model_name=MODEL_NAME)
+
+
 @chat_gpt_bp.route("/chat", methods=["POST"])
 def chat_post():
     """Handle ChatGPT messages and return the response."""

--- a/templates/oracle_gpt.html
+++ b/templates/oracle_gpt.html
@@ -1,0 +1,230 @@
+{% extends "base.html" %}
+
+{% block title %}GPT Oracle{% endblock %}
+
+{% block extra_styles %}
+{{ super() }}
+<link rel="stylesheet" href="{{ url_for('static', filename='css/title_bar.css') }}">
+<link rel="stylesheet" href="{{ url_for('static', filename='css/sonic_themes.css') }}">
+<link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=IM+Fell+English+SC&display=swap">
+<style>
+  body {
+    margin: 0;
+    background: url('{{ url_for('static', filename='images/oracle_wall.jpg') }}') no-repeat center center fixed;
+    background-size: cover;
+    font-family: 'IM Fell English SC', serif;
+    color: var(--text, #e0e0ff);
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    height: 100vh;
+    overflow: hidden;
+  }
+
+  .oracle-container {
+    margin-top: 6rem;
+    width: 90%;
+    max-width: 1200px;
+    background-color: rgba(0, 0, 0, 0.5);
+    border-radius: 12px;
+    padding: 2rem;
+    box-shadow: 0 0 25px #5f00ff88;
+  }
+  body.wide-mode .oracle-container { max-width: 1600px; }
+  body.fitted-mode .oracle-container { max-width: 1280px; }
+  body.mobile-mode .oracle-container { width: 100%; }
+
+  .panel {
+    background: var(--card-bg, rgba(25, 25, 50, 0.9));
+    border: var(--panel-border-width, 1px) solid var(--panel-border, #5f00ff);
+    border-radius: 12px;
+    padding: 1rem;
+    display: flex;
+    flex-direction: column;
+    box-shadow: 0 0 20px #5f00ff88;
+    height: 100%;
+    color: var(--text);
+  }
+
+  .oracle-btns {
+    display: flex;
+    justify-content: space-around;
+    margin-bottom: 1rem;
+  }
+
+  .oracle-btn {
+    background: transparent;
+    border: 1px solid var(--panel-border, #b4a0ff);
+    color: var(--text, #e0e0ff);
+    padding: 0.5rem 1rem;
+    border-radius: 8px;
+    cursor: pointer;
+    font-size: 1.2rem;
+    transition: all 0.3s ease-in-out;
+  }
+
+  .oracle-btn:hover {
+    background-color: #5f00ff33;
+    border-color: #fff;
+  }
+
+  .oracle-output,
+  .chat-window {
+    flex-grow: 1;
+    overflow-y: auto;
+    background: var(--container-bg, rgba(0, 0, 0, 0.3));
+    padding: 1rem;
+    border-radius: 10px;
+    font-family: monospace;
+    position: relative;
+  }
+
+  .chat-message {
+    margin: 0.5rem 0;
+  }
+
+  .chat-message.user {
+    color: #b0ffb0;
+  }
+
+  .chat-message.bot {
+    color: #a0c4ff;
+  }
+
+  .typing-indicator {
+    position: absolute;
+    bottom: 1rem;
+    left: 1rem;
+    font-size: 0.85rem;
+    color: #aaa;
+    font-style: italic;
+  }
+
+  .input-area {
+    margin-top: 1rem;
+    display: flex;
+    gap: 0.5rem;
+  }
+
+  .input-area input {
+    flex: 1;
+    padding: 0.75rem;
+    font-size: 1rem;
+    border-radius: 8px;
+    border: none;
+    outline: none;
+  }
+
+  .input-area button {
+    padding: 0.75rem 1rem;
+    font-size: 1rem;
+    border-radius: 8px;
+    border: none;
+    background: #5f00ff;
+    color: #fff;
+    cursor: pointer;
+    transition: background 0.3s;
+  }
+
+  .input-area button:hover {
+    background: #7f00ff;
+  }
+
+  #tokenInfo {
+    font-size: 0.8rem;
+    opacity: 0.7;
+    text-align: right;
+    margin-top: 0.3rem;
+  }
+</style>
+{% endblock %}
+
+{% block content %}
+{% set title_text = 'GPT Oracle Interface' %}
+{% include "title_bar.html" %}
+
+<div class="oracle-container container mt-3 mb-4 p-3 rounded shadow">
+  <h2 class="text-center mb-4" style="color: #c7bfff;">🔮 Speak to the Oracle</h2>
+  <div class="row g-4">
+    <div class="col-md-6">
+      <div class="panel d-flex flex-column h-100">
+        <div class="oracle-btns">
+          <button class="oracle-btn" data-topic="portfolio">📂</button>
+          <button class="oracle-btn" data-topic="alerts">🚨</button>
+          <button class="oracle-btn" data-topic="prices">💲</button>
+          <button class="oracle-btn" data-topic="system">🖥️</button>
+        </div>
+        <div id="oracleOutput" class="oracle-output">Ask a question to receive wisdom from the stars.</div>
+      </div>
+    </div>
+
+    <div class="col-md-6">
+      <div class="panel d-flex flex-column h-100">
+        <div id="chatWindow" class="chat-window"></div>
+        <div class="typing-indicator" id="typingIndicator" style="display:none;">The spirits are whispering...</div>
+        <div class="input-area">
+          <input type="text" id="userInput" placeholder="Speak your query...">
+          <button id="sendBtn">Send</button>
+        </div>
+        <div id="tokenInfo"></div>
+      </div>
+    </div>
+  </div>
+</div>
+{% endblock %}
+
+{% block extra_scripts %}
+{{ super() }}
+<script src="{{ url_for('static', filename='js/title_bar.js') }}" defer></script>
+<script src="{{ url_for('static', filename='js/sonic_theme_toggle.js') }}"></script>
+<script src="{{ url_for('static', filename='js/layout_mode.js') }}"></script>
+<script>
+  const chatWindow = document.getElementById('chatWindow');
+  const userInput = document.getElementById('userInput');
+  const sendBtn = document.getElementById('sendBtn');
+  const tokenInfo = document.getElementById('tokenInfo');
+  const oracleBtns = document.querySelectorAll('.oracle-btn');
+  const oracleOutput = document.getElementById('oracleOutput');
+  const typingIndicator = document.getElementById('typingIndicator');
+
+  function addMessage(content, role) {
+    const div = document.createElement('div');
+    div.className = `chat-message ${role}`;
+    div.textContent = content;
+    chatWindow.appendChild(div);
+    chatWindow.scrollTop = chatWindow.scrollHeight;
+  }
+
+  sendBtn.addEventListener('click', async () => {
+    const message = userInput.value.trim();
+    if (!message) return;
+    addMessage(message, 'user');
+    userInput.value = '';
+    typingIndicator.style.display = 'block';
+
+    const res = await fetch('{{ url_for("chat_gpt_bp.chat_post") }}', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ message })
+    });
+
+    const data = await res.json();
+    addMessage(data.reply, 'bot');
+    typingIndicator.style.display = 'none';
+
+    if (data.usage) {
+      tokenInfo.textContent = `Prompt: ${data.usage.prompt_tokens}, Completion: ${data.usage.completion_tokens}, Total: ${data.usage.total_tokens}`;
+    }
+  });
+
+  oracleBtns.forEach((btn) => {
+    btn.addEventListener('click', async () => {
+      const topic = btn.getAttribute('data-topic');
+      oracleOutput.textContent = "Consulting the spirits...";
+      const res = await fetch(`/gpt/oracle/${topic}`);
+      const data = await res.json();
+      oracleOutput.textContent = data.reply;
+    });
+  });
+</script>
+{% endblock %}

--- a/templates/title_bar.html
+++ b/templates/title_bar.html
@@ -8,7 +8,7 @@
     <a class="btn nav-btn" href="/alerts/status_page" title="Alert Status"><span>🚨</span></a>
     <a class="btn nav-btn" href="/sonic_labs/hedge_report" title="Hedge Report"><span>🦔</span></a>
     <a class="btn nav-btn" href="/system/wallets" title="Wallet Manager"><span>💼</span></a>
-    <a class="btn nav-btn" href="{{ url_for('chat_gpt_bp.chat') }}" title="ChatGPT"><span>🤖</span></a>
+    <a class="btn nav-btn" href="{{ url_for('chat_gpt_bp.oracle_ui') }}" title="GPT Oracle"><span>🤖</span></a>
   </div>
   <div class="title-bar-center text-center" style="font-size:1.3rem;font-weight:bold;letter-spacing:0.04em;">
     {% if title_image %}


### PR DESCRIPTION
## Summary
- create a new `oracle_gpt.html` template honoring theme and layout toggles
- expose `/GPT/oracle` route in `chat_gpt_bp.py`
- update navigation link in `title_bar.html` to use the new Oracle page

## Testing
- `pytest -q`