### PR TITLE
Update GPT templates to include sonic_titles stylesheet

### DIFF
--- a/templates/chat_gpt.html
+++ b/templates/chat_gpt.html
@@ -6,6 +6,7 @@
 {{ super() }}
 <link rel="stylesheet" href="{{ url_for('static', filename='css/title_bar.css') }}">
 <link rel="stylesheet" href="{{ url_for('static', filename='css/sonic_themes.css') }}">
+<link rel="stylesheet" href="{{ url_for('static', filename='css/sonic_titles.css') }}">
 <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=IM+Fell+English+SC&display=swap">
 <style>
   body {

--- a/templates/oracle_gpt.html
+++ b/templates/oracle_gpt.html
@@ -6,6 +6,7 @@
 {{ super() }}
 <link rel="stylesheet" href="{{ url_for('static', filename='css/title_bar.css') }}">
 <link rel="stylesheet" href="{{ url_for('static', filename='css/sonic_themes.css') }}">
+<link rel="stylesheet" href="{{ url_for('static', filename='css/sonic_titles.css') }}">
 <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=IM+Fell+English+SC&display=swap">
 <style>
   body {


### PR DESCRIPTION
## Summary
- add `sonic_titles.css` link in `chat_gpt.html`
- add `sonic_titles.css` link in `oracle_gpt.html`

## Testing
- `pytest -q`