### PR TITLE
Shorten dashboard panels

### DIFF
--- a/static/css/sonic_dashboard.css
+++ b/static/css/sonic_dashboard.css
@@ -67,9 +67,17 @@
 
 /* Slightly smaller card sizing within the portfolio panel */
 .portfolio-panel .flip-card {
-  flex-basis: 100px;
-  max-width: 110px;
-  min-width: 90px;
+  /* Cards trimmed to 75% of the original size */
+  flex-basis: 75px;   /* tweak values below as needed */
+  max-width: 83px;
+  min-width: 68px;
+}
+
+/* Monitor panel card sizing also reduced by 25% */
+.monitor-panel .flip-card {
+  flex-basis: 83px;
+  max-width: 90px;
+  min-width: 75px;
 }
 
 /* Inner container to enable 3D flip */


### PR DESCRIPTION
## Summary
- shrink portfolio and monitor panel cards to reduce panel height

## Testing
- `pytest -q`