### PR TITLE
Add Oracle component wrapper for GPT

### DIFF
--- a/gpt/__init__.py
+++ b/gpt/__init__.py
@@ -4,6 +4,13 @@ from .chat_gpt_bp import chat_gpt_bp
 from .gpt_bp import gpt_bp
 from .gpt_core import GPTCore
 from .create_gpt_context_service import create_gpt_context_service
+from .oracle import Oracle
 
-__all__ = ["chat_gpt_bp", "gpt_bp", "GPTCore", "create_gpt_context_service"]
+__all__ = [
+    "chat_gpt_bp",
+    "gpt_bp",
+    "GPTCore",
+    "create_gpt_context_service",
+    "Oracle",
+]
 

--- a/gpt/gpt_bp.py
+++ b/gpt/gpt_bp.py
@@ -30,14 +30,8 @@ def ask_portfolio():
 def oracle(topic: str):
     """Handle oracle queries for various topics."""
     core = GPTCore()
-    if topic == 'portfolio':
-        result = core.ask_gpt_about_portfolio()
-    elif topic == 'alerts':
-        result = core.ask_gpt_about_alerts()
-    elif topic == 'prices':
-        result = core.ask_gpt_about_prices()
-    elif topic == 'system':
-        result = core.ask_gpt_about_system()
-    else:
+    try:
+        result = core.ask_oracle(topic)
+        return jsonify({"reply": result})
+    except ValueError:
         return jsonify({"error": "Unknown topic"}), 400
-    return jsonify({"reply": result})

--- a/gpt/oracle.py
+++ b/gpt/oracle.py
@@ -1,0 +1,66 @@
+import json
+from typing import List
+
+from gpt.context_loader import get_context_messages
+
+
+class Oracle:
+    """Bundle context and instructions for GPT queries."""
+
+    def __init__(self, topic: str, data_locker, instructions: str = ""):
+        self.topic = topic
+        self.data_locker = data_locker
+        self.instructions = instructions or self.default_instructions()
+
+    def default_instructions(self) -> str:
+        return {
+            "portfolio": "Provide a portfolio analysis summary.",
+            "alerts": "Summarize the current alert state.",
+            "prices": "Summarize the market trends.",
+            "system": "Summarize the system health status.",
+        }.get(self.topic, "Assist the user.")
+
+    def get_context(self) -> List[dict]:
+        """Return GPT chat messages based on the requested topic."""
+        static_context = get_context_messages()
+
+        if self.topic == "portfolio":
+            return [
+                {"role": "system", "content": "You are a portfolio analysis assistant."},
+                *static_context,
+                {"role": "user", "content": self.instructions},
+            ]
+
+        if self.topic == "alerts":
+            alerts = self.data_locker.alerts.get_all_alerts()[:20]
+            return [
+                {"role": "system", "content": "You summarize alert information."},
+                {"role": "system", "content": json.dumps({"alerts": alerts})},
+                {"role": "user", "content": self.instructions},
+            ]
+
+        if self.topic == "prices":
+            prices = self.data_locker.prices.get_all_prices()[:20]
+            return [
+                {"role": "system", "content": "You summarize price information."},
+                {"role": "system", "content": json.dumps({"prices": prices})},
+                {"role": "user", "content": self.instructions},
+            ]
+
+        if self.topic == "system":
+            system = self.data_locker.get_last_update_times()
+            return [
+                {"role": "system", "content": "You report system status."},
+                {"role": "system", "content": json.dumps(system)},
+                {"role": "user", "content": self.instructions},
+            ]
+
+        raise ValueError(f"Unsupported topic: {self.topic}")
+
+    def to_dict(self) -> dict:
+        """Return a JSON serializable representation of the oracle request."""
+        return {
+            "topic": self.topic,
+            "instructions": self.instructions,
+            "context": self.get_context(),
+        }

--- a/tests/test_oracle_component.py
+++ b/tests/test_oracle_component.py
@@ -1,0 +1,55 @@
+import importlib.util
+from pathlib import Path
+import types
+import sys
+
+
+def load_module():
+    base = Path(__file__).resolve().parents[1] / "gpt"
+    pkg = types.ModuleType("gpt")
+    sys.modules.setdefault("gpt", pkg)
+
+    ctx_path = base / "context_loader.py"
+    ctx_spec = importlib.util.spec_from_file_location("gpt.context_loader", ctx_path)
+    ctx_mod = importlib.util.module_from_spec(ctx_spec)
+    assert ctx_spec and ctx_spec.loader
+    ctx_spec.loader.exec_module(ctx_mod)
+    sys.modules["gpt.context_loader"] = ctx_mod
+    setattr(pkg, "context_loader", ctx_mod)
+
+    path = base / "oracle.py"
+    spec = importlib.util.spec_from_file_location("gpt.oracle", path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec and spec.loader
+    spec.loader.exec_module(module)
+    sys.modules["gpt.oracle"] = module
+    return module
+
+
+def test_oracle_get_context(monkeypatch):
+    mod = load_module()
+
+    class DummyAlerts:
+        def get_all_alerts(self):
+            return ["a1", "a2"]
+
+    class DummyPrices:
+        def get_all_prices(self):
+            return [1, 2, 3]
+
+    class DummyLocker:
+        def __init__(self):
+            self.alerts = DummyAlerts()
+            self.prices = DummyPrices()
+
+        def get_last_update_times(self):
+            return {"x": 1}
+
+    def fake_ctx():
+        return [{"role": "system", "content": "ctx"}]
+
+    monkeypatch.setattr(mod, "get_context_messages", fake_ctx)
+    oracle = mod.Oracle("portfolio", DummyLocker())
+    msgs = oracle.get_context()
+    assert msgs[0]["role"] == "system"
+    assert msgs[-1]["content"] == oracle.instructions


### PR DESCRIPTION
## Summary
- create `Oracle` class to encapsulate GPT query context
- integrate Oracle into `GPTCore` via new `ask_oracle` method
- simplify GPT blueprint route to use Oracle
- export Oracle from package
- add basic Oracle unit test

## Testing
- `pytest -q`