### PR TITLE
Add alert existence check to prevent duplicates

### DIFF
--- a/tests/test_db_portfolio_alert_toggle.py
+++ b/tests/test_db_portfolio_alert_toggle.py
@@ -87,5 +87,5 @@ def test_db_portfolio_alert_toggle(tmp_path, monkeypatch):
     alerts3 = dl.db.fetch_all("alerts")
     portfolio_alerts3 = [a for a in alerts3 if a["alert_class"] == "Portfolio"]
     print(f"Portfolio alerts after re-enable run: {len(portfolio_alerts3)}")
-    assert len(portfolio_alerts3) == 12
+    assert len(portfolio_alerts3) == 6
 


### PR DESCRIPTION
## Summary
- add `_alert_exists` helper in `AlertStore` to query for duplicates
- use the helper in portfolio, position and global alert creation
- update test to expect idempotent alert creation

## Testing
- `pytest -q`
