### PR TITLE
Add monitor success statuses

### DIFF
--- a/dashboard/dashboard_service.py
+++ b/dashboard/dashboard_service.py
@@ -252,6 +252,13 @@ def get_dashboard_context(data_locker, system_core=None):
         "last_xcom_time": ls.get_status("xcom_monitor").get("last_timestamp"),
     }
 
+    monitor_statuses = {
+        "price": ls.get_status("price_monitor").get("status", "Unknown"),
+        "positions": ls.get_status("position_monitor").get("status", "Unknown"),
+        "operations": ls.get_status("operations_monitor").get("status", "Unknown"),
+        "xcom": ls.get_status("xcom_monitor").get("status", "Unknown"),
+    }
+
     # Monitor card data (real, not canned)
     price_monitor_history = get_latest_price_monitor_history(data_locker)
     positions_monitor_history = get_latest_positions_monitor_history(data_locker)
@@ -354,4 +361,8 @@ def get_dashboard_context(data_locker, system_core=None):
         "positions_monitor_history": positions_monitor_history,
         "operations_monitor_history": operations_monitor_history,
         "xcom_monitor_history": xcom_monitor_history,
+        "price_monitor_status": monitor_statuses["price"],
+        "positions_monitor_status": monitor_statuses["positions"],
+        "operations_monitor_status": monitor_statuses["operations"],
+        "xcom_monitor_status": monitor_statuses["xcom"],
     }

--- a/monitor/base_monitor.py
+++ b/monitor/base_monitor.py
@@ -11,9 +11,18 @@ class BaseMonitor:
 
         log.banner(f"🚀 Running {self.name}")
         result = {}
+        status = "Success"
         try:
             result = self._do_work()
-            status = "Success" if result.get("errors", 0) == 0 else "Error"
+
+            if isinstance(result, dict):
+                if "status" in result:
+                    status = "Success" if str(result.get("status")).lower() == "success" else "Error"
+                elif "success" in result:
+                    status = "Success" if result.get("success") else "Error"
+                elif "errors" in result:
+                    status = "Success" if result.get("errors", 0) == 0 else "Error"
+            
 
             # 🧾 Log to DB-backed ledger
             locker = DataLocker(DB_PATH)

--- a/monitor/operations_monitor.py
+++ b/monitor/operations_monitor.py
@@ -81,7 +81,7 @@ class OperationsMonitor(BaseMonitor):
             and api_status.get("twilio_success")
         )
 
-        payload = {"startup": startup, "api_status": api_status}
+        payload = {"startup": startup, "api_status": api_status, "success": overall_success}
 
         self.data_locker.ledger.insert_ledger_entry(
             monitor_name=self.name,

--- a/templates/monitor_cards.html
+++ b/templates/monitor_cards.html
@@ -15,7 +15,7 @@
           <div class="flip-card-back status-card monitor-style {{ item.color }}">
             {% if item.title == "Price" %}
               <strong>Status:</strong>
-              {% if item.color == 'green' %}✅{% elif item.color == 'yellow' %}⚠️{% else %}❌{% endif %}
+              {% if price_monitor_status == 'Success' %}✅{% else %}❌{% endif %}
               <ul class="mini-list">
                 {% for asset in price_monitor_history %}
                   <li>{{ asset.icon }} <span class="text-bold">{{ asset.label }}:</span>
@@ -24,6 +24,8 @@
                 {% endfor %}
               </ul>
             {% elif item.title == "Positions" %}
+              <strong>Status:</strong>
+              {% if positions_monitor_status == 'Success' %}✅{% else %}❌{% endif %}
               <ul class="mini-list">
                 {% for sync in positions_monitor_history %}
                   <li>+{{ sync.imported }} <span style="color:#ffaa1a;">Skipped: {{ sync.skipped }}</span>
@@ -32,6 +34,8 @@
                 {% endfor %}
               </ul>
             {% elif item.title == "Operations" %}
+              <strong>Status:</strong>
+              {% if operations_monitor_status == 'Success' %}✅{% else %}❌{% endif %}
               <ul class="mini-list">
                 {% for op in operations_monitor_history %}
                   <li>
@@ -42,6 +46,8 @@
                 {% endfor %}
               </ul>
             {% elif item.title == "Xcom" %}
+              <strong>Status:</strong>
+              {% if xcom_monitor_status == 'Success' %}✅{% else %}❌{% endif %}
               <ul class="mini-list">
                 {% for xc in xcom_monitor_history %}
                   <li>{{ xc.comm_type }} from {{ xc.source }} @ {{ xc.timestamp }}</li>

--- a/xcom/xcom_core.py
+++ b/xcom/xcom_core.py
@@ -59,7 +59,9 @@ class XComCore:
             "results": results
         })
 
-        # 🧾 Write to monitor ledger with initiator
+        # Determine overall success and log to ledger with initiator
+        success = any(v is True for v in results.values()) and error_msg is None
+
         try:
             from data.data_locker import DataLocker
             from core.constants import DB_PATH
@@ -67,7 +69,6 @@ class XComCore:
 
             dl = DataLocker(DB_PATH)
             ledger = DLMonitorLedgerManager(dl.db)
-            status = "Success" if any(v is True for v in results.values()) else "Error"
 
             metadata = {
                 "level": level,
@@ -76,11 +77,17 @@ class XComCore:
                 "recipient": recipient,
                 "results": results
             }
-            ledger.insert_ledger_entry("xcom_monitor", status, metadata)
+            ledger.insert_ledger_entry(
+                "xcom_monitor",
+                "Success" if success else "Error",
+                metadata,
+            )
 
         except Exception as e:
             log.error(f"🧨 Failed to write xcom_monitor ledger: {e}", source="XComCore")
 
+        # Include success flag in return payload for monitor use
+        results["success"] = success
         return results
 
 


### PR DESCRIPTION
## Summary
- make XComCore return success flag and log results properly
- handle status logic in BaseMonitor
- store overall_success in OperationsMonitor payload
- expose monitor status info to dashboard
- display last run result on monitor cards

## Testing
- `pytest -q`