### PR TITLE
Implement OracleCore orchestrator

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,9 @@ with status code `0` on success and `1` on failure.
 
 Run `python sonic_app.py` and navigate to `/GPT/chat` to open the oracle front end.
 The page shows four buttons—`portfolio`, `alerts`, `prices`, and `system`—that
-query the `/gpt/oracle/<topic>` API and display the reply.
+query the `/gpt/oracle/<topic>` API and display the reply using **OracleCore**.
+OracleCore aggregates context, applies optional strategies, and sends the prompt
+to GPT.
 
 The API can be called directly as well:
 

--- a/gpt/gpt_core.py
+++ b/gpt/gpt_core.py
@@ -10,7 +10,7 @@ from openai import OpenAI
 from data.data_locker import DataLocker
 from core.constants import DB_PATH
 from .create_gpt_context_service import create_gpt_context_service
-from .oracle import Oracle
+from oracle_core import OracleCore
 
 
 class GPTCore:
@@ -95,15 +95,12 @@ class GPTCore:
             self.logger.exception(f"GPT analysis failed: {e}")
             return f"Error: {e}"
 
-    def ask_oracle(self, topic: str, instructions: str = "") -> str:
-        """Query GPT for a specific topic using the Oracle wrapper."""
-        oracle = Oracle(topic, self.data_locker, instructions)
-        messages = oracle.get_context()
+    def ask_oracle(self, topic: str, strategy_name: str | None = None) -> str:
+        """Query GPT for a specific topic using :class:`OracleCore`."""
+        oracle = OracleCore(self.data_locker)
+        oracle.client = self.client
         try:
-            response = self.client.chat.completions.create(
-                model="gpt-3.5-turbo", messages=messages
-            )
-            return response.choices[0].message.content.strip()
+            return oracle.ask(topic, strategy_name)
         except Exception as e:  # pragma: no cover - depends on OpenAI API
             self.logger.exception(f"GPT oracle query failed: {e}")
             return f"Error: {e}"

--- a/oracle_core/__init__.py
+++ b/oracle_core/__init__.py
@@ -1,0 +1,18 @@
+"""Oracle core package."""
+
+from .oracle_core import OracleCore
+from .strategy_manager import StrategyManager, Strategy
+from .portfolio_topic_handler import PortfolioTopicHandler
+from .alerts_topic_handler import AlertsTopicHandler
+from .prices_topic_handler import PricesTopicHandler
+from .system_topic_handler import SystemTopicHandler
+
+__all__ = [
+    "OracleCore",
+    "StrategyManager",
+    "Strategy",
+    "PortfolioTopicHandler",
+    "AlertsTopicHandler",
+    "PricesTopicHandler",
+    "SystemTopicHandler",
+]

--- a/oracle_core/alerts_topic_handler.py
+++ b/oracle_core/alerts_topic_handler.py
@@ -1,0 +1,17 @@
+from typing import Dict
+
+from gpt.oracle_data_service import OracleDataService
+
+
+class AlertsTopicHandler:
+    """Provide alerts context for GPT."""
+
+    output_key = "alerts"
+    system_message = "You summarize alert information."
+
+    def __init__(self, data_locker):
+        self.data_service = OracleDataService(data_locker)
+
+    def get_context(self) -> Dict:
+        alerts = self.data_service.fetch_alerts()
+        return {self.output_key: alerts}

--- a/oracle_core/oracle_core.py
+++ b/oracle_core/oracle_core.py
@@ -1,0 +1,90 @@
+import json
+import os
+from typing import Dict, List, Optional
+
+try:
+    from openai import OpenAI
+except Exception:  # pragma: no cover - optional dependency
+    OpenAI = None
+
+from .strategy_manager import StrategyManager
+from .portfolio_topic_handler import PortfolioTopicHandler
+from .alerts_topic_handler import AlertsTopicHandler
+from .prices_topic_handler import PricesTopicHandler
+from .system_topic_handler import SystemTopicHandler
+
+
+class OracleCore:
+    """Main orchestrator for GPT oracle queries."""
+
+    DEFAULT_SYSTEM_MESSAGES = {
+        "portfolio": "You are a portfolio analysis assistant.",
+        "alerts": "You summarize alert information.",
+        "prices": "You summarize price information.",
+        "system": "You report system status.",
+    }
+
+    DEFAULT_INSTRUCTIONS = {
+        "portfolio": "Provide a portfolio analysis summary.",
+        "alerts": "Summarize the current alert state.",
+        "prices": "Summarize the market trends.",
+        "system": "Summarize the system health status.",
+    }
+
+    def __init__(self, data_locker):
+        self.data_locker = data_locker
+        if OpenAI:
+            api_key = os.getenv("OPENAI_API_KEY") or os.getenv("OPEN_AI_KEY") or ""
+            self.client = OpenAI(api_key=api_key) if api_key else None
+        else:
+            self.client = None
+        self.strategy_manager = StrategyManager()
+        self.handlers: Dict[str, object] = {}
+        self.register_topic_handler("portfolio", PortfolioTopicHandler(data_locker))
+        self.register_topic_handler("alerts", AlertsTopicHandler(data_locker))
+        self.register_topic_handler("prices", PricesTopicHandler(data_locker))
+        self.register_topic_handler("system", SystemTopicHandler(data_locker))
+
+    # public API
+    def register_topic_handler(self, name: str, handler: object):
+        self.handlers[name] = handler
+
+    def build_prompt(self, topic: str, context: Dict, instructions: str) -> List[Dict]:
+        system_msg = self.DEFAULT_SYSTEM_MESSAGES.get(topic, "You assist the user.")
+        return [
+            {"role": "system", "content": system_msg},
+            {"role": "system", "content": json.dumps(context)},
+            {"role": "user", "content": instructions},
+        ]
+
+    def query_gpt(self, messages: List[Dict]) -> str:
+        if self.client is None:
+            raise RuntimeError("OpenAI client not configured")
+        response = self.client.chat.completions.create(model="gpt-3.5-turbo", messages=messages)
+        return response.choices[0].message.content.strip()
+
+    def ask(self, topic: str, strategy_name: Optional[str] = None) -> str:
+        if topic not in self.handlers:
+            raise ValueError(f"Unsupported topic: {topic}")
+        handler = self.handlers[topic]
+        context = handler.get_context()
+        instructions = self.DEFAULT_INSTRUCTIONS.get(topic, "Assist the user.")
+        if strategy_name:
+            strategy = self.strategy_manager.get(strategy_name)
+            context = strategy.apply(context)
+            instructions = strategy.instructions or instructions
+        messages = self.build_prompt(topic, context, instructions)
+        return self.query_gpt(messages)
+
+    def to_dict(self, topic: str, strategy_name: Optional[str] = None) -> Dict:
+        if topic not in self.handlers:
+            raise ValueError(f"Unsupported topic: {topic}")
+        handler = self.handlers[topic]
+        context = handler.get_context()
+        instructions = self.DEFAULT_INSTRUCTIONS.get(topic, "Assist the user.")
+        if strategy_name:
+            strategy = self.strategy_manager.get(strategy_name)
+            context = strategy.apply(context)
+            instructions = strategy.instructions or instructions
+        messages = self.build_prompt(topic, context, instructions)
+        return {"topic": topic, "messages": messages}

--- a/oracle_core/portfolio_topic_handler.py
+++ b/oracle_core/portfolio_topic_handler.py
@@ -1,0 +1,17 @@
+from typing import Dict
+
+from gpt.oracle_data_service import OracleDataService
+
+
+class PortfolioTopicHandler:
+    """Provide portfolio context for GPT."""
+
+    output_key = "portfolio"
+    system_message = "You are a portfolio analysis assistant."
+
+    def __init__(self, data_locker):
+        self.data_service = OracleDataService(data_locker)
+
+    def get_context(self) -> Dict:
+        snapshot = self.data_service.fetch_portfolio()
+        return {self.output_key: snapshot}

--- a/oracle_core/prices_topic_handler.py
+++ b/oracle_core/prices_topic_handler.py
@@ -1,0 +1,17 @@
+from typing import Dict
+
+from gpt.oracle_data_service import OracleDataService
+
+
+class PricesTopicHandler:
+    """Provide market prices context for GPT."""
+
+    output_key = "prices"
+    system_message = "You summarize price information."
+
+    def __init__(self, data_locker):
+        self.data_service = OracleDataService(data_locker)
+
+    def get_context(self) -> Dict:
+        prices = self.data_service.fetch_prices()
+        return {self.output_key: prices}

--- a/oracle_core/strategy_manager.py
+++ b/oracle_core/strategy_manager.py
@@ -1,0 +1,49 @@
+import json
+from typing import Dict, Iterable
+
+
+class Strategy:
+    """Simple strategy container."""
+
+    def __init__(self, data: Dict):
+        self.name = data.get("name", "")
+        self.description = data.get("description", "")
+        self.modifiers = data.get("modifiers", {})
+        self.instructions = data.get("instructions", "")
+
+    def apply(self, context: Dict) -> Dict:
+        """Apply modifiers to the context. This minimal implementation just
+        attaches the modifiers under ``strategy_modifiers``."""
+        if not self.modifiers:
+            return context
+        new_ctx = dict(context)
+        new_ctx["strategy_modifiers"] = self.modifiers
+        return new_ctx
+
+
+class StrategyManager:
+    """Manage loading and retrieval of strategies."""
+
+    def __init__(self):
+        self._strategies: Dict[str, Strategy] = {}
+
+    def load(self, strategies: Iterable[Dict]):
+        for data in strategies:
+            self.register(data)
+
+    def load_from_file(self, path: str):
+        with open(path, "r", encoding="utf-8") as fh:
+            data = json.load(fh)
+        if isinstance(data, dict) and "name" in data:
+            self.register(data)
+        elif isinstance(data, list):
+            self.load(data)
+
+    def register(self, data: Dict):
+        strat = data if isinstance(data, Strategy) else Strategy(data)
+        self._strategies[strat.name] = strat
+
+    def get(self, name: str) -> Strategy:
+        if name not in self._strategies:
+            raise KeyError(name)
+        return self._strategies[name]

--- a/oracle_core/system_topic_handler.py
+++ b/oracle_core/system_topic_handler.py
@@ -1,0 +1,17 @@
+from typing import Dict
+
+from gpt.oracle_data_service import OracleDataService
+
+
+class SystemTopicHandler:
+    """Provide system state context for GPT."""
+
+    output_key = "system"
+    system_message = "You report system status."
+
+    def __init__(self, data_locker):
+        self.data_service = OracleDataService(data_locker)
+
+    def get_context(self) -> Dict:
+        system = self.data_service.fetch_system()
+        return {self.output_key: system}

--- a/tests/test_oracle_core_component.py
+++ b/tests/test_oracle_core_component.py
@@ -1,23 +1,16 @@
 import importlib.util
 from pathlib import Path
-import types
 import sys
+import types
 
 
 def load_module():
-    base = Path(__file__).resolve().parents[1] / "gpt"
+    base = Path(__file__).resolve().parents[1]
+    gpt_base = base / "gpt"
     pkg = types.ModuleType("gpt")
     sys.modules.setdefault("gpt", pkg)
 
-    ctx_path = base / "context_loader.py"
-    ctx_spec = importlib.util.spec_from_file_location("gpt.context_loader", ctx_path)
-    ctx_mod = importlib.util.module_from_spec(ctx_spec)
-    assert ctx_spec and ctx_spec.loader
-    ctx_spec.loader.exec_module(ctx_mod)
-    sys.modules["gpt.context_loader"] = ctx_mod
-    setattr(pkg, "context_loader", ctx_mod)
-
-    ods_path = base / "oracle_data_service.py"
+    ods_path = gpt_base / "oracle_data_service.py"
     ods_spec = importlib.util.spec_from_file_location("gpt.oracle_data_service", ods_path)
     ods_mod = importlib.util.module_from_spec(ods_spec)
     assert ods_spec and ods_spec.loader
@@ -25,29 +18,29 @@ def load_module():
     sys.modules["gpt.oracle_data_service"] = ods_mod
     setattr(pkg, "oracle_data_service", ods_mod)
 
-    path = base / "oracle.py"
-    spec = importlib.util.spec_from_file_location("gpt.oracle", path)
+    path = base / "oracle_core" / "oracle_core.py"
+    spec = importlib.util.spec_from_file_location("oracle_core.oracle_core", path)
     module = importlib.util.module_from_spec(spec)
     assert spec and spec.loader
     spec.loader.exec_module(module)
-    sys.modules["gpt.oracle"] = module
+    sys.modules["oracle_core.oracle_core"] = module
     return module
 
 
-def test_oracle_get_context(monkeypatch):
+def test_oracle_core_build_prompt(monkeypatch):
     mod = load_module()
 
     class DummyAlerts:
         def get_all_alerts(self):
-            return ["a1", "a2"]
+            return ["a1"]
 
     class DummyPrices:
         def get_all_prices(self):
-            return [1, 2, 3]
+            return [1]
 
     class DummyPortfolio:
         def get_latest_snapshot(self):
-            return {"id": "snap1"}
+            return {"id": "snap"}
 
     class DummyLocker:
         def __init__(self):
@@ -58,11 +51,9 @@ def test_oracle_get_context(monkeypatch):
         def get_last_update_times(self):
             return {"x": 1}
 
-    def fake_ctx():
-        return [{"role": "system", "content": "ctx"}]
-
-    monkeypatch.setattr(mod, "get_context_messages", fake_ctx)
-    oracle = mod.Oracle("portfolio", DummyLocker())
-    msgs = oracle.get_context()
-    assert msgs[0]["role"] == "system"
-    assert msgs[-1]["content"] == oracle.instructions
+    oc = mod.OracleCore(DummyLocker())
+    oc.strategy_manager.register({"name": "test", "instructions": "do"})
+    monkeypatch.setattr(oc, "query_gpt", lambda messages: messages)
+    messages = oc.ask("portfolio", "test")
+    assert messages[0]["role"] == "system"
+    assert messages[-1]["content"] == "do"


### PR DESCRIPTION
## Summary
- add new OracleCore package with topic handlers and strategy manager
- update GPTCore to use OracleCore
- replace old oracle test with oracle_core test
- update GPT Oracle docs for OracleCore

## Testing
- `pytest tests/test_oracle_core_component.py::test_oracle_core_build_prompt -q`
- `pytest -q`
