### PR TITLE
Refactor Twilio config to API

### DIFF
--- a/monitor/twilio_monitor.py
+++ b/monitor/twilio_monitor.py
@@ -18,7 +18,7 @@ class TwilioMonitor(BaseMonitor):
         self.config_service = XComConfigService(self.dl.system)
 
     def _do_work(self):
-        cfg = self.config_service.get_provider("twilio") or {}
+        cfg = self.config_service.get_provider("api") or {}
         service = CheckTwilioHeartbeartService(cfg)
         result = service.check(dry_run=True)
         return result

--- a/operations_console.py
+++ b/operations_console.py
@@ -108,9 +108,9 @@ def menu_xcom():
         elif choice == "3":
             xcom.send_notification("HIGH", subj, msg)
         elif choice == "4":
-            twilio_cfg = xcom.config_service.get_provider("twilio")
-            masked = {k: ("****" if "token" in k or "sid" in k else v) for k, v in twilio_cfg.items()}
-            log.info("Twilio Config", payload=masked)
+            api_cfg = xcom.config_service.get_provider("api")
+            masked = {k: ("****" if "token" in k or "sid" in k else v) for k, v in api_cfg.items()}
+            log.info("API Config", payload=masked)
         elif choice.lower() == "b":
             break
         pause()

--- a/system/death_nail_service.py
+++ b/system/death_nail_service.py
@@ -59,9 +59,9 @@ class DeathNailService:
             # 📡 4. Optional escalation
             if self.xcom and hasattr(self.xcom, "send_notification"):
                 try:
-                    twilio = self.xcom.config_service.get_provider("twilio") or {}
-                    if not twilio.get("account_sid"):
-                        raise Exception("Twilio config missing or incomplete")
+                    api_cfg = self.xcom.config_service.get_provider("api") or {}
+                    if not api_cfg.get("account_sid"):
+                        raise Exception("API config missing or incomplete")
 
                     self.xcom.send_notification(
                         level=level,

--- a/templates/system/xcom_config.html
+++ b/templates/system/xcom_config.html
@@ -22,34 +22,34 @@
     <div class="col-md-6">
       <form method="POST" action="{{ url_for('system.save_xcom_config') }}">
 
-        <!-- TWILIO CONFIG -->
-        <div class="accordion mb-4" id="twilioAccordion">
+        <!-- API CONFIG -->
+        <div class="accordion mb-4" id="apiAccordion">
           <div class="accordion-item">
             <h2 class="accordion-header">
-              <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#twilioCollapse">
-                <i class="fab fa-twilio me-2 text-danger"></i>Twilio Settings
+              <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#apiCollapse">
+                <i class="fab fa-twilio me-2 text-danger"></i>API Settings
               </button>
             </h2>
-            <div id="twilioCollapse" class="accordion-collapse collapse">
+            <div id="apiCollapse" class="accordion-collapse collapse">
               <div class="accordion-body row g-3">
-                {% set twilio = xcom_config.get("twilio", {}) %}
+                {% set api = xcom_config.get("api", {}) %}
                 <div class="col-md-6"><label class="form-label">Account SID</label>
-                  <input type="text" name="twilio[account_sid]" value="{{ twilio.account_sid or '' }}" class="form-control">
+                  <input type="text" name="api[account_sid]" value="{{ api.account_sid or '' }}" class="form-control">
                 </div>
                 <div class="col-md-6"><label class="form-label">Auth Token</label>
                   <div class="input-group">
-                    <input type="password" id="authTokenField" name="twilio[auth_token]" value="{{ twilio.auth_token or '' }}" class="form-control">
+                    <input type="password" id="authTokenField" name="api[auth_token]" value="{{ api.auth_token or '' }}" class="form-control">
                     <button type="button" class="btn btn-outline-secondary" onclick="toggleToken()">👁️</button>
                   </div>
                 </div>
                 <div class="col-md-6"><label class="form-label">Flow SID</label>
-                  <input type="text" name="twilio[flow_sid]" value="{{ twilio.flow_sid or '' }}" class="form-control">
+                  <input type="text" name="api[flow_sid]" value="{{ api.flow_sid or '' }}" class="form-control">
                 </div>
                 <div class="col-md-6"><label class="form-label">From Phone</label>
-                  <input type="text" name="twilio[default_from_phone]" value="{{ twilio.default_from_phone or '' }}" class="form-control">
+                  <input type="text" name="api[default_from_phone]" value="{{ api.default_from_phone or '' }}" class="form-control">
                 </div>
                 <div class="col-md-6"><label class="form-label">To Phone</label>
-                  <input type="text" name="twilio[default_to_phone]" value="{{ twilio.default_to_phone or '' }}" class="form-control">
+                  <input type="text" name="api[default_to_phone]" value="{{ api.default_to_phone or '' }}" class="form-control">
                 </div>
 
                 <div class="col-md-12">
@@ -58,12 +58,12 @@
 
                 <!-- 🔍 DISPLAY VALUES -->
                 <div class="col-md-12 mt-2">
-                  <label class="form-label text-muted">🔍 Loaded Twilio Config (read-only)</label>
+                  <label class="form-label text-muted">🔍 Loaded API Config (read-only)</label>
                   <div class="p-2 border bg-light text-monospace small rounded">
-                    <div>Account SID: <strong>{{ twilio.account_sid or "—" }}</strong></div>
-                    <div>Flow SID: <strong>{{ twilio.flow_sid or "—" }}</strong></div>
-                    <div>From Phone: <strong>{{ twilio.default_from_phone or "—" }}</strong></div>
-                    <div>To Phone: <strong>{{ twilio.default_to_phone or "—" }}</strong></div>
+                    <div>Account SID: <strong>{{ api.account_sid or "—" }}</strong></div>
+                    <div>Flow SID: <strong>{{ api.flow_sid or "—" }}</strong></div>
+                    <div>From Phone: <strong>{{ api.default_from_phone or "—" }}</strong></div>
+                    <div>To Phone: <strong>{{ api.default_to_phone or "—" }}</strong></div>
                   </div>
                 </div>
               </div>
@@ -195,10 +195,10 @@ function checkApiStatus(btn) {
       } else {
         out.push("❌ ChatGPT: " + data.chatgpt);
       }
-      if (data.twilio === "ok") {
-        out.push("✅ Twilio reachable");
+      if (data.api === "ok") {
+        out.push("✅ API reachable");
       } else {
-        out.push("❌ Twilio: " + data.twilio);
+        out.push("❌ API: " + data.api);
       }
       document.getElementById("apiStatusResult").textContent = out.join("\n");
     })

--- a/tests/test_operations_monitor.py
+++ b/tests/test_operations_monitor.py
@@ -127,6 +127,6 @@ def test_check_api_status_logs_to_xcom(monkeypatch):
     result = monitor.check_api_status()
 
     assert result["chatgpt_success"] is True
-    assert result["twilio_success"] is True
+    assert result["api_success"] is True
     assert captured["monitor_name"] == "xcom_monitor"
     assert captured["status"] == "Success"

--- a/xcom/xcom_config_service.py
+++ b/xcom/xcom_config_service.py
@@ -52,8 +52,8 @@ class XComConfigService:
                     },
                 }
 
-            # Fallback for Twilio if missing/empty
-            if name == "twilio" and not provider:
+            # Fallback for API (Twilio) if missing/empty
+            if name == "api" and not provider:
                 provider = {
                     "enabled": True,
                     "account_sid": os.getenv("TWILIO_ACCOUNT_SID"),
@@ -74,7 +74,7 @@ class XComConfigService:
                 smtp["default_recipient"] = _resolve_env(smtp.get("default_recipient"), "SMTP_DEFAULT_RECIPIENT")
                 provider["smtp"] = smtp
 
-            if name == "twilio":
+            if name == "api":
                 provider["account_sid"] = _resolve_env(provider.get("account_sid"), "TWILIO_ACCOUNT_SID")
                 provider["auth_token"] = _resolve_env(provider.get("auth_token"), "TWILIO_AUTH_TOKEN")
                 provider["flow_sid"] = _resolve_env(provider.get("flow_sid"), "TWILIO_FLOW_SID")

--- a/xcom/xcom_core.py
+++ b/xcom/xcom_core.py
@@ -27,7 +27,7 @@ class XComCore:
         """
         email_cfg = self.config_service.get_provider("email") or {}
         sms_cfg = self.config_service.get_provider("sms") or {}
-        voice_cfg = self.config_service.get_provider("twilio") or {}
+        voice_cfg = self.config_service.get_provider("api") or {}
 
         results = {"email": False, "sms": False, "voice": False, "sound": None}
         error_msg = None

--- a/xcom/xcom_core_spec.md
+++ b/xcom/xcom_core_spec.md
@@ -31,7 +31,7 @@ XComCore(dl_sys_data_manager)
 ```python
 send_notification(level, subject, body, recipient="", initiator="system") -> dict
 ```
-- Retrieves provider configs (`email`, `sms`, `twilio`).
+- Retrieves provider configs (`email`, `sms`, `api`).
 - Based on `level` dispatches to `SMSService`, `VoiceService`, `EmailService` and
   optionally plays a sound.
 - Results and errors are logged and written to the `xcom_monitor` ledger.


### PR DESCRIPTION
## Summary
- rename Twilio provider config to `api`
- update UI fields and script
- rename validation route
- adjust monitors and services for new config name
- fix affected tests

## Testing
- `pytest -q`