### PR TITLE
Remove unused alert file warnings and add alert limits import/export

### DIFF
--- a/app/alerts_bp.py
+++ b/app/alerts_bp.py
@@ -285,6 +285,31 @@ def update_config():
         logger.error(f"Failed to update alert config: {e}", exc_info=True)
         return jsonify({"success": False, "error": str(e)}), 500
 
+
+@alerts_bp.route('/export_config', methods=['GET'])
+def export_config():
+    """Export alert limits configuration as JSON."""
+    try:
+        cfg = current_app.data_locker.system.get_var("alert_limits") or {}
+        return jsonify(cfg)
+    except Exception as e:
+        logger.error(f"Failed to export alert config: {e}", exc_info=True)
+        return jsonify({"success": False, "error": str(e)}), 500
+
+
+@alerts_bp.route('/import_config', methods=['POST'])
+def import_config():
+    """Import alert limits configuration from JSON payload."""
+    try:
+        payload = request.get_json(force=True)
+        if not isinstance(payload, dict):
+            return jsonify({"success": False, "error": "Expected JSON object"}), 400
+        current_app.data_locker.system.set_var("alert_limits", payload)
+        return jsonify({"success": True, "message": "Configuration imported"})
+    except Exception as e:
+        logger.error(f"Failed to import alert config: {e}", exc_info=True)
+        return jsonify({"success": False, "error": str(e)}), 500
+
 # --- Internal helpers ---
 
 def _parse_nested_form(form: dict) -> dict:

--- a/static/js/alert_limits.js
+++ b/static/js/alert_limits.js
@@ -1,0 +1,63 @@
+window.addEventListener('DOMContentLoaded', () => {
+  const importBtn = document.getElementById('importConfig');
+  const exportBtn = document.getElementById('exportConfig');
+
+  if (exportBtn) exportBtn.addEventListener('click', async evt => {
+    evt.preventDefault();
+    try {
+      const resp = await fetch('/alerts/export_config');
+      const data = await resp.json();
+      const blob = new Blob([JSON.stringify(data, null, 2)], { type: 'application/json' });
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement('a');
+      a.href = url;
+      a.download = 'alert_limits.json';
+      a.click();
+      URL.revokeObjectURL(url);
+      if (typeof showToast === 'function') {
+        showToast('✅ Exported alert_limits.json');
+      }
+    } catch (err) {
+      if (typeof showToast === 'function') {
+        showToast('❌ Failed to export alert limits', true);
+      }
+    }
+  });
+
+  if (importBtn) importBtn.addEventListener('click', evt => {
+    evt.preventDefault();
+    const input = document.createElement('input');
+    input.type = 'file';
+    input.accept = '.json';
+    input.addEventListener('change', async () => {
+      const file = input.files[0];
+      if (!file) return;
+      try {
+        const text = await file.text();
+        const payload = JSON.parse(text);
+        const resp = await fetch('/alerts/import_config', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(payload)
+        });
+        const data = await resp.json();
+        if (resp.ok && data.success) {
+          if (typeof showToast === 'function') {
+            showToast('✅ Configuration imported');
+          }
+          location.reload();
+        } else {
+          const msg = data.error || resp.statusText;
+          if (typeof showToast === 'function') {
+            showToast(`❌ Import failed: ${msg}`, true);
+          }
+        }
+      } catch (err) {
+        if (typeof showToast === 'function') {
+          showToast('❌ Error importing alert limits', true);
+        }
+      }
+    });
+    input.click();
+  });
+});

--- a/templates/alert_limits.html
+++ b/templates/alert_limits.html
@@ -50,6 +50,11 @@
 
   <p>This page will hold alert configuration options.</p>
 
+  <div class="d-flex justify-content-end mb-3 gap-2">
+    <button id="importConfig" class="btn btn-secondary">Import</button>
+    <button id="exportConfig" class="btn btn-secondary">Export</button>
+  </div>
+
   <form id="alertForm" method="POST" action="{{ url_for('alerts_bp.update_config') }}">
 
     <ul class="nav nav-tabs" id="alertTabNav" role="tablist">
@@ -156,4 +161,5 @@
   <script src="{{ url_for('static', filename='js/title_bar.js') }}" defer></script>
   <script src="{{ url_for('static', filename='js/sonic_theme_toggle.js') }}"></script>
   <script src="{{ url_for('static', filename='js/layout_mode.js') }}"></script>
+  <script src="{{ url_for('static', filename='js/alert_limits.js') }}"></script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- suppress warning when alert_limits.json is missing
- provide endpoints to import and export alert limits
- wire alert limits UI to import/export JSON
- JS handler for new import/export buttons

## Testing
- `pytest -q`
