### PR TITLE
Add GPT strategy tests

### DIFF
--- a/gpt/gpt_bp.py
+++ b/gpt/gpt_bp.py
@@ -30,8 +30,9 @@ def ask_portfolio():
 def oracle(topic: str):
     """Handle oracle queries for various topics."""
     core = GPTCore()
+    strategy = request.args.get("strategy")
     try:
-        result = core.ask_oracle(topic)
+        result = core.ask_oracle(topic, strategy)
         return jsonify({"reply": result})
     except ValueError:
         return jsonify({"error": "Unknown topic"}), 400

--- a/oracle_core/strategies/safe.json
+++ b/oracle_core/strategies/safe.json
@@ -1,0 +1,6 @@
+{
+  "name": "safe",
+  "description": "Prefer conservative actions",
+  "modifiers": {"risk_level": "low"},
+  "instructions": "Answer briefly and focus on risk mitigation."
+}

--- a/oracle_core/strategy_manager.py
+++ b/oracle_core/strategy_manager.py
@@ -26,6 +26,21 @@ class StrategyManager:
 
     def __init__(self):
         self._strategies: Dict[str, Strategy] = {}
+        self._load_builtin()
+
+    def _load_builtin(self):
+        """Load strategies bundled with the package."""
+        import os
+
+        base = os.path.join(os.path.dirname(__file__), "strategies")
+        if not os.path.isdir(base):  # pragma: no cover - defensive
+            return
+        for name in os.listdir(base):
+            if name.endswith(".json"):
+                try:
+                    self.load_from_file(os.path.join(base, name))
+                except Exception:
+                    continue
 
     def load(self, strategies: Iterable[Dict]):
         for data in strategies:
@@ -47,3 +62,7 @@ class StrategyManager:
         if name not in self._strategies:
             raise KeyError(name)
         return self._strategies[name]
+
+    def list_strategies(self) -> Iterable[str]:
+        """Return the names of all loaded strategies."""
+        return list(self._strategies.keys())

--- a/tests/test_gpt_strategies.py
+++ b/tests/test_gpt_strategies.py
@@ -1,0 +1,106 @@
+import importlib
+import importlib.util
+import sys
+import types
+from pathlib import Path
+import json
+
+import pytest
+
+
+def test_strategy_manager_builtin_loading():
+    sm_mod = importlib.import_module("oracle_core.strategy_manager")
+    manager = sm_mod.StrategyManager()
+    assert "safe" in manager.list_strategies()
+
+
+def setup_core(monkeypatch):
+    base = Path(__file__).resolve().parents[1]
+
+    class DummyClient:
+        def __init__(self, *a, **k):
+            pass
+
+    monkeypatch.setitem(sys.modules, "openai", types.SimpleNamespace(OpenAI=DummyClient))
+    monkeypatch.setenv("OPENAI_API_KEY", "test")
+    monkeypatch.setitem(sys.modules, "dotenv", types.SimpleNamespace(load_dotenv=lambda *a, **k: False))
+    sys.modules.pop("gpt", None)
+    import importlib
+    importlib.invalidate_caches()
+
+    class DummyAlerts:
+        def get_all_alerts(self):
+            return []
+
+    class DummyPrices:
+        def get_all_prices(self):
+            return []
+
+    class DummyPortfolio:
+        def get_latest_snapshot(self):
+            return {}
+
+    class DummySystem:
+        def get_last_update_times(self):
+            return {}
+
+    class DummyLocker:
+        def __init__(self, *a, **k):
+            self.alerts = DummyAlerts()
+            self.prices = DummyPrices()
+            self.portfolio = DummyPortfolio()
+            self.system = DummySystem()
+
+        def get_last_update_times(self):
+            return {}
+
+        def get_portfolio_history(self):
+            return []
+
+    monkeypatch.setitem(sys.modules, "data.data_locker", types.SimpleNamespace(DataLocker=DummyLocker))
+
+    import oracle_core
+    monkeypatch.setattr(oracle_core.OracleCore, "query_gpt", lambda self, msgs: msgs)
+
+    gc_path = base / "gpt" / "gpt_core.py"
+    pkg = types.ModuleType("gpt")
+    pkg.__path__ = [str(base / "gpt")]
+    sys.modules.setdefault("gpt", pkg)
+    spec = importlib.util.spec_from_file_location("gpt.gpt_core", gc_path)
+    gpt_core = importlib.util.module_from_spec(spec)
+    assert spec and spec.loader
+    spec.loader.exec_module(gpt_core)
+    return gpt_core.GPTCore
+
+
+def test_gptcore_ask_oracle_applies_strategy(monkeypatch):
+    GPTCore = setup_core(monkeypatch)
+    core = GPTCore()
+    messages = core.ask_oracle("portfolio", "safe")
+    ctx = json.loads(messages[1]["content"])
+    assert ctx.get("strategy_modifiers", {}).get("risk_level") == "low"
+    assert messages[-1]["content"] == "Answer briefly and focus on risk mitigation."
+
+
+@pytest.fixture
+def client(monkeypatch):
+    flask = importlib.import_module("flask")
+    if not getattr(flask, "Flask", None):
+        pytest.skip("Flask not available", allow_module_level=True)
+    GPTCore = setup_core(monkeypatch)
+    bp_mod = importlib.import_module("gpt.gpt_bp")
+    from flask import Flask
+    app = Flask(__name__)
+    app.config["TESTING"] = True
+    app.register_blueprint(bp_mod.gpt_bp)
+    with app.test_client() as client:
+        yield client
+
+
+def test_oracle_endpoint_with_strategy(client):
+    resp = client.get("/gpt/oracle/portfolio?strategy=safe")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    ctx = json.loads(data["reply"][1]["content"])
+    assert ctx.get("strategy_modifiers", {}).get("risk_level") == "low"
+    assert data["reply"][-1]["content"] == "Answer briefly and focus on risk mitigation."


### PR DESCRIPTION
## Summary
- load strategies automatically in `StrategyManager`
- support `strategy` query parameter for the oracle API
- bundle built-in `safe` strategy definition
- add tests for strategy loading and application

## Testing
- `pytest -q`