### PR TITLE
Add profit management strategy

### DIFF
--- a/oracle_core/strategies/profit_management.json
+++ b/oracle_core/strategies/profit_management.json
@@ -1,0 +1,9 @@
+{
+  "name": "profit_management",
+  "description": "Balanced strategy focusing on maximizing profits while managing risk.",
+  "modifiers": {
+    "profit_focus": "balanced",
+    "risk_level": "moderate"
+  },
+  "instructions": "Provide guidance to enhance profits without excessive risk."
+}

--- a/tests/test_gpt_strategies.py
+++ b/tests/test_gpt_strategies.py
@@ -12,6 +12,7 @@ def test_strategy_manager_builtin_loading():
     sm_mod = importlib.import_module("oracle_core.strategy_manager")
     manager = sm_mod.StrategyManager()
     assert "safe" in manager.list_strategies()
+    assert "profit_management" in manager.list_strategies()
 
 
 def test_strategy_manager_alias(monkeypatch):


### PR DESCRIPTION
## Summary
- add `profit_management.json` built-in strategy
- check new strategy loads in `StrategyManager`

## Testing
- `pytest tests/test_gpt_strategies.py tests/test_oracle_core_component.py -q`