### PR TITLE
Deprecate dynamic hedging strategy

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,10 @@ curl "http://localhost:5000/gpt/oracle/portfolio?strategy=none"
 Replace `portfolio` with any other topic to receive a short summary. Use the
 `strategy` query parameter to apply a named strategy (defaults to `none`).
 
+The previously available `dynamic_hedging` strategy has been deprecated and is no
+longer shown in the UI. The JSON file remains under `oracle_core/strategies` for
+backward compatibility.
+
 ## Required Environment Variables
 
 The application expects several environment variables for email and Twilio

--- a/dynamic_hedging_gamma_scalping_whitepaper.md
+++ b/dynamic_hedging_gamma_scalping_whitepaper.md
@@ -1,5 +1,8 @@
 # Dynamic Hedging and Gamma Scalping for Perpetual Futures
 
+**Deprecated:** The `dynamic_hedging` strategy is no longer exposed in the UI but
+the configuration file is retained for backward compatibility.
+
 ## Abstract
 This white paper presents an in-depth exploration of dynamic delta hedging and gamma scalping strategies tailored for high-volatility cryptocurrency markets. Focusing on Bitcoin (BTC), Ethereum (ETH), and Solana (SOL) perpetual futures, we bridge theoretical models with practical execution techniques suited to near-term trading. Key concepts from options theory (e.g., delta-neutral positioning and gamma trading) are adapted to perpetual swap markets, emphasizing real-time adjustments and automated strategy implementation. We outline how an AI-driven “Oracle Core” system can integrate strategy logic, live position and market data, and user-defined risk profiles to actively manage exposure. Clearly defined sections cover relevant models, execution methods on crypto futures platforms (like Jupiter’s exchange), and tools for monitoring risk. The goal is to provide both a conceptual framework and actionable guidance—including example workflows, supporting tables, and diagrams—for implementing dynamic hedging and gamma scalping in an automated trading context.
 

--- a/oracle_core/strategies/dynamic_hedging.json
+++ b/oracle_core/strategies/dynamic_hedging.json
@@ -1,5 +1,6 @@
 {
   "name": "dynamic_hedging",
+  "deprecated": true,
   "description": "Implements a volatility-sensitive delta-neutral strategy with real-time gamma scalping influences.",
   "modifiers": {
     "hedging_frequency": "adaptive",

--- a/templates/chat_gpt.html
+++ b/templates/chat_gpt.html
@@ -168,7 +168,6 @@
         <option value="">Default</option>
         <option value="cautious">Cautious</option>
         <option value="aggressive">Aggressive</option>
-        <option value="dynamic_hedging">Dynamic Hedging</option>
       </select>
       <div class="oracle-btns">
         <button class="oracle-btn" data-topic="portfolio">📂</button>

--- a/templates/oracle_gpt.html
+++ b/templates/oracle_gpt.html
@@ -157,7 +157,6 @@
           <option value="">Default</option>
           <option value="cautious">Cautious</option>
           <option value="aggressive">Aggressive</option>
-          <option value="dynamic_hedging">Dynamic Hedging</option>
         </select>
         <div class="oracle-btns">
           <button class="oracle-btn" data-topic="portfolio">📂</button>


### PR DESCRIPTION
## Summary
- remove deprecated strategy from UI dropdowns
- mark `dynamic_hedging` strategy JSON as deprecated
- call out deprecation in README and whitepaper

## Testing
- `pytest -q`