### PR TITLE
Implement persona strategy merging for OracleCore

### DIFF
--- a/oracle_core/__init__.py
+++ b/oracle_core/__init__.py
@@ -2,6 +2,7 @@
 
 from .oracle_core import OracleCore
 from .strategy_manager import StrategyManager, Strategy
+from .persona_manager import PersonaManager, Persona
 from .oracle_data_service import OracleDataService
 from .portfolio_topic_handler import PortfolioTopicHandler
 from .alerts_topic_handler import AlertsTopicHandler
@@ -12,6 +13,8 @@ __all__ = [
     "OracleCore",
     "StrategyManager",
     "Strategy",
+    "PersonaManager",
+    "Persona",
     "OracleDataService",
     "PortfolioTopicHandler",
     "AlertsTopicHandler",

--- a/oracle_core/persona_manager.py
+++ b/oracle_core/persona_manager.py
@@ -1,0 +1,52 @@
+import json
+import os
+from pathlib import Path
+from typing import Dict, Iterable
+
+
+class Persona:
+    """Simple persona container."""
+
+    def __init__(self, data: Dict):
+        self.name = data.get("name", "")
+        self.description = data.get("description", "")
+        self.strategy_weights = data.get("strategy_weights", {})
+        self.instructions = data.get("instructions", "")
+
+
+class PersonaManager:
+    """Load and retrieve personas."""
+
+    def __init__(self):
+        self._personas: Dict[str, Persona] = {}
+        self._load_builtin()
+
+    def _load_builtin(self):
+        base = Path(__file__).with_name("personas")
+        if base.is_dir():
+            for path in base.glob("*.json"):
+                self.load_from_file(path)
+
+    def load(self, personas: Iterable[Dict]):
+        for data in personas:
+            self.register(data)
+
+    def load_from_file(self, path: str):
+        with open(path, "r", encoding="utf-8") as fh:
+            data = json.load(fh)
+        if isinstance(data, dict) and "name" in data:
+            self.register(data)
+        elif isinstance(data, list):
+            self.load(data)
+
+    def register(self, data: Dict):
+        persona = data if isinstance(data, Persona) else Persona(data)
+        self._personas[persona.name] = persona
+
+    def get(self, name: str) -> Persona:
+        if name not in self._personas:
+            raise KeyError(name)
+        return self._personas[name]
+
+    def list_personas(self):
+        return list(self._personas.keys())

--- a/oracle_core/personas/risk_averse.json
+++ b/oracle_core/personas/risk_averse.json
@@ -1,0 +1,8 @@
+{
+  "name": "risk_averse",
+  "strategy_weights": {
+    "safe": 0.7,
+    "cautious": 0.3
+  },
+  "instructions": "Adopt a conservative trading approach."
+}

--- a/tests/test_gpt_strategies.py
+++ b/tests/test_gpt_strategies.py
@@ -22,6 +22,15 @@ def test_strategy_manager_alias(monkeypatch):
     assert strat.name == "degen"
 
 
+def test_merge_modifiers():
+    sm_mod = importlib.import_module("oracle_core.strategy_manager")
+    Strategy = sm_mod.Strategy
+    mods = [({"a": 1, "b": [1]}, 1.0), ({"a": 3, "b": [2]}, 1.0)]
+    merged = Strategy.merge_modifiers(mods)
+    assert merged["a"] == 2
+    assert sorted(merged["b"]) == [1, 2]
+
+
 def setup_core(monkeypatch):
     base = Path(__file__).resolve().parents[1]
 
@@ -112,3 +121,15 @@ def test_oracle_endpoint_with_strategy(client):
     ctx = json.loads(data["reply"][1]["content"])
     assert ctx.get("strategy_modifiers", {}).get("risk_level") == "low"
     assert data["reply"][-1]["content"] == "Answer briefly and focus on risk mitigation."
+
+
+def test_persona_application(monkeypatch):
+    GPTCore = setup_core(monkeypatch)
+    core = GPTCore()
+    messages = core.ask_oracle("portfolio", "risk_averse")
+    ctx = json.loads(messages[1]["content"])
+    mods = ctx.get("strategy_modifiers", {})
+    assert mods.get("risk_level") == "low"
+    assert mods.get("risk_tolerance") == "very_low"
+    text = messages[-1]["content"]
+    assert "Adopt a conservative trading approach." in text


### PR DESCRIPTION
## Summary
- support personas via new `PersonaManager`
- extend `Strategy` with `merge_modifiers` helper for combining modifier dictionaries
- allow `OracleCore.ask` and `to_dict` to handle persona names
- ship a `risk_averse` persona definition
- test weighted modifier merging and persona application

## Testing
- `pytest tests/test_gpt_strategies.py::test_persona_application -q`
- `pytest tests/test_gpt_strategies.py -q`
- `pytest tests/test_oracle_core_component.py -q`
- `pytest tests/test_gpt_strategies.py tests/test_oracle_core_component.py -q`