### PR TITLE
Add oracle query endpoint with persona support

### DIFF
--- a/gpt/gpt_bp.py
+++ b/gpt/gpt_bp.py
@@ -2,6 +2,8 @@ import logging
 from flask import Blueprint, jsonify, request
 
 from .gpt_core import GPTCore
+from .persona_manager import PersonaManager
+from oracle_core import OracleCore
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.DEBUG)
@@ -37,3 +39,42 @@ def oracle(topic: str):
         return jsonify({"reply": result})
     except ValueError:
         return jsonify({"error": "Unknown topic"}), 400
+
+
+@gpt_bp.route('/gpt/oracle/query', methods=['GET'])
+def oracle_query():
+    """Query GPT using a persona and optional topic."""
+    persona_name = request.args.get('persona', '').strip()
+    if not persona_name:
+        return jsonify({"error": "persona parameter required"}), 400
+    topic = request.args.get('topic', 'portfolio').strip() or 'portfolio'
+
+    core = GPTCore()
+    pm = PersonaManager()
+    try:
+        persona = pm.get(persona_name)
+    except KeyError:
+        return jsonify({"error": "Unknown persona"}), 400
+
+    oracle = OracleCore(core.data_locker)
+    oracle.client = core.client
+
+    if topic not in oracle.handlers:
+        return jsonify({"error": "Unknown topic"}), 400
+
+    handler = oracle.handlers[topic]
+    context = handler.get_context()
+
+    instructions = persona.instructions or OracleCore.DEFAULT_INSTRUCTIONS.get(topic, "Assist the user.")
+    system_msg = persona.system_message or OracleCore.DEFAULT_SYSTEM_MESSAGES.get(topic, "You assist the user.")
+
+    messages = oracle.build_prompt(topic, context, instructions)
+    if messages:
+        messages[0]["content"] = system_msg
+
+    try:
+        reply = oracle.query_gpt(messages)
+        return jsonify({"reply": reply})
+    except Exception as ex:  # pragma: no cover - depends on OpenAI API
+        logger.exception("Oracle query failed: %s", ex)
+        return jsonify({"error": str(ex)}), 500

--- a/gpt/persona_manager.py
+++ b/gpt/persona_manager.py
@@ -1,0 +1,49 @@
+import json
+import os
+from dataclasses import dataclass
+from typing import Dict
+
+
+@dataclass
+class Persona:
+    """Simple persona container."""
+
+    name: str
+    system_message: str = ""
+    instructions: str = ""
+
+
+class PersonaManager:
+    """Load and retrieve persona definitions."""
+
+    def __init__(self):
+        self._personas: Dict[str, Persona] = {}
+        self._load_builtin()
+        # Always provide a fallback persona
+        self._personas.setdefault("default", Persona("default"))
+
+    def _load_builtin(self):
+        base = os.path.join(os.path.dirname(__file__), "personas")
+        if not os.path.isdir(base):
+            return
+        for fname in os.listdir(base):
+            if not fname.endswith(".json"):
+                continue
+            path = os.path.join(base, fname)
+            try:
+                with open(path, "r", encoding="utf-8") as fh:
+                    data = json.load(fh)
+            except Exception:
+                continue
+            name = data.get("name") or os.path.splitext(fname)[0]
+            persona = Persona(
+                name=name,
+                system_message=data.get("system_message", ""),
+                instructions=data.get("instructions", ""),
+            )
+            self._personas[name] = persona
+
+    def get(self, name: str) -> Persona:
+        if name not in self._personas:
+            raise KeyError(name)
+        return self._personas[name]


### PR DESCRIPTION
## Summary
- introduce `PersonaManager` for loading persona details
- extend GPT blueprint with `/gpt/oracle/query` endpoint
- update unit tests for new endpoint

## Testing
- `pytest -q`