### PR TITLE
Add persona manager and tests for oracle query

### DIFF
--- a/gpt/gpt_bp.py
+++ b/gpt/gpt_bp.py
@@ -37,3 +37,31 @@ def oracle(topic: str):
         return jsonify({"reply": result})
     except ValueError:
         return jsonify({"error": "Unknown topic"}), 400
+
+
+@gpt_bp.route('/gpt/oracle/query', methods=['POST'])
+def oracle_query():
+    """Return persona-aware modifiers for a topic."""
+    data = request.get_json() or {}
+    topic = data.get("topic")
+    persona = data.get("persona")
+    if not topic:
+        return jsonify({"error": "Missing topic"}), 400
+
+    base_mods = {
+        "distanceWeight": 0.6,
+        "leverageWeight": 0.3,
+        "collateralWeight": 0.1,
+    }
+    from oracle_core.persona_manager import PersonaManager
+
+    if persona:
+        manager = PersonaManager()
+        try:
+            mods = manager.merge_modifiers(base_mods, persona)
+        except KeyError:
+            return jsonify({"error": "Unknown persona"}), 400
+    else:
+        mods = base_mods
+
+    return jsonify({"reply": {"topic": topic, "modifiers": mods}})

--- a/oracle_core/__init__.py
+++ b/oracle_core/__init__.py
@@ -2,6 +2,7 @@
 
 from .oracle_core import OracleCore
 from .strategy_manager import StrategyManager, Strategy
+from .persona_manager import PersonaManager, Persona
 from .oracle_data_service import OracleDataService
 from .portfolio_topic_handler import PortfolioTopicHandler
 from .alerts_topic_handler import AlertsTopicHandler
@@ -12,6 +13,8 @@ __all__ = [
     "OracleCore",
     "StrategyManager",
     "Strategy",
+    "PersonaManager",
+    "Persona",
     "OracleDataService",
     "PortfolioTopicHandler",
     "AlertsTopicHandler",

--- a/oracle_core/persona_manager.py
+++ b/oracle_core/persona_manager.py
@@ -1,0 +1,47 @@
+import json
+import os
+from typing import Dict, Iterable
+
+class Persona:
+    """Simple persona container."""
+
+    def __init__(self, data: Dict):
+        self.name = data.get("name", "")
+        self.description = data.get("description", "")
+        self.modifiers = data.get("modifiers", {})
+
+class PersonaManager:
+    """Load and manage personas."""
+
+    def __init__(self, base_dir: str | None = None):
+        self.base_dir = base_dir or os.path.join(os.path.dirname(__file__), "personas")
+        self._personas: Dict[str, Persona] = {}
+        self._load_all()
+
+    def _load_all(self):
+        if not os.path.isdir(self.base_dir):
+            return
+        for fname in os.listdir(self.base_dir):
+            if fname.endswith(".json"):
+                self.load_from_file(os.path.join(self.base_dir, fname))
+
+    def load_from_file(self, path: str):
+        with open(path, "r", encoding="utf-8") as fh:
+            data = json.load(fh)
+        self.register(data)
+
+    def register(self, data: Dict):
+        persona = data if isinstance(data, Persona) else Persona(data)
+        self._personas[persona.name] = persona
+
+    def get(self, name: str) -> Persona:
+        return self._personas[name]
+
+    def list_personas(self) -> Iterable[str]:
+        return list(self._personas.keys())
+
+    def merge_modifiers(self, base: Dict[str, float], persona_name: str) -> Dict[str, float]:
+        persona = self.get(persona_name)
+        merged = dict(base)
+        merged.update(persona.modifiers)
+        return merged

--- a/oracle_core/personas/wizard.json
+++ b/oracle_core/personas/wizard.json
@@ -1,0 +1,8 @@
+{
+  "name": "wizard",
+  "description": "A mystical risk wizard persona.",
+  "modifiers": {
+    "distanceWeight": 0.9,
+    "leverageWeight": 0.05
+  }
+}

--- a/tests/test_oracle_persona_query.py
+++ b/tests/test_oracle_persona_query.py
@@ -1,0 +1,46 @@
+import importlib
+import importlib.util
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+flask = importlib.import_module("flask")
+if not getattr(flask, "Flask", None):
+    pytest.skip("Flask not available", allow_module_level=True)
+from flask import Flask
+
+
+def load_blueprint():
+    base = Path(__file__).resolve().parents[1]
+    pkg = types.ModuleType("gpt")
+    pkg.__path__ = [str(base / "gpt")]
+    sys.modules.setdefault("gpt", pkg)
+
+    path = base / "gpt" / "gpt_bp.py"
+    spec = importlib.util.spec_from_file_location("gpt.gpt_bp", path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec and spec.loader
+    spec.loader.exec_module(module)
+    return module.gpt_bp
+
+
+@pytest.fixture
+def client():
+    bp = load_blueprint()
+    app = Flask(__name__)
+    app.config["TESTING"] = True
+    app.register_blueprint(bp)
+    with app.test_client() as client:
+        yield client
+
+
+def test_oracle_query_with_persona(client):
+    resp = client.post(
+        "/gpt/oracle/query",
+        json={"topic": "portfolio", "persona": "wizard"},
+    )
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["reply"]["modifiers"]["distanceWeight"] == 0.9

--- a/tests/test_persona_loading.py
+++ b/tests/test_persona_loading.py
@@ -1,0 +1,13 @@
+import importlib
+
+
+def test_persona_manager_merge():
+    pm_mod = importlib.import_module("oracle_core.persona_manager")
+    manager = pm_mod.PersonaManager()
+    assert "wizard" in manager.list_personas()
+
+    base = {"distanceWeight": 0.6, "leverageWeight": 0.3, "collateralWeight": 0.1}
+    merged = manager.merge_modifiers(base, "wizard")
+    assert merged["distanceWeight"] == 0.9
+    assert merged["leverageWeight"] == 0.05
+    assert merged["collateralWeight"] == 0.1


### PR DESCRIPTION
## Summary
- add persona manager with sample wizard persona
- expose Persona classes via oracle_core package
- extend GPT blueprint with `/gpt/oracle/query` endpoint
- test persona loading and persona-based oracle query

## Testing
- `pytest -q`