### PR TITLE
Add system connectivity checks

### DIFF
--- a/system/system_core.py
+++ b/system/system_core.py
@@ -1,5 +1,7 @@
 # 🧠 SystemCore — updated for theme profile support
 
+import os
+
 from alert_core.threshold_service import ThresholdService
 from wallets.wallet_service import WalletService
 from wallets.wallet_core import WalletCore
@@ -7,6 +9,12 @@ from system.theme_service import ThemeService
 from xcom.xcom_core import XComCore
 from system.death_nail_service import DeathNailService
 from core.logging import log
+from core.constants import JUPITER_API_BASE
+
+try:  # Optional dependency
+    import requests
+except Exception:  # pragma: no cover - requests may be missing
+    requests = None
 
 class SystemCore:
     def __init__(self, data_locker):
@@ -129,3 +137,44 @@ class SystemCore:
         except Exception as e:
             self.log.error(f"Failed to get active profile name: {e}", source="SystemCore")
             return ""
+
+    # --- Connectivity Checks ---
+    def check_twilio_api(self) -> str:
+        """Return 'ok' if Twilio credentials are valid, otherwise error text."""
+        try:
+            from xcom.check_twilio_heartbeart_service import CheckTwilioHeartbeartService
+
+            result = CheckTwilioHeartbeartService({}).check(dry_run=True)
+            if result.get("success"):
+                return "ok"
+            return result.get("error", "unknown error")
+        except Exception as exc:  # pragma: no cover - optional dependency
+            self.log.error(f"Twilio heartbeat check failed: {exc}", source="SystemCore")
+            return str(exc)
+
+    def check_chatgpt(self) -> str:
+        """Return 'ok' if ChatGPT API is reachable, else an error message."""
+        api_key = os.getenv("OPENAI_API_KEY") or os.getenv("OPEN_AI_KEY")
+        if not api_key:
+            return "missing api key"
+        try:
+            from openai import OpenAI  # type: ignore
+
+            client = OpenAI(api_key=api_key)
+            client.chat.completions.create(model="gpt-3.5-turbo", messages=[{"role": "user", "content": "ping"}])
+            return "ok"
+        except Exception as exc:  # pragma: no cover - network dependent
+            self.log.error(f"ChatGPT check failed: {exc}", source="SystemCore")
+            return str(exc)
+
+    def check_jupiter(self) -> str:
+        """Return 'ok' if the Jupiter API endpoint is reachable."""
+        if not requests:  # pragma: no cover - optional dependency
+            return "requests_unavailable"
+        try:
+            resp = requests.get(f"{JUPITER_API_BASE}/v1/perp_markets", timeout=5)
+            resp.raise_for_status()
+            return "ok"
+        except Exception as exc:  # pragma: no cover - network dependent
+            self.log.error(f"Jupiter API check failed: {exc}", source="SystemCore")
+            return str(exc)

--- a/tests/test_system_core_connectivity.py
+++ b/tests/test_system_core_connectivity.py
@@ -1,0 +1,87 @@
+import importlib
+import sys
+import types
+from types import SimpleNamespace
+
+import pytest
+
+
+def load_core(monkeypatch, requests_module=None):
+    sc = importlib.import_module("system.system_core")
+    importlib.reload(sc)
+    if requests_module is not None:
+        monkeypatch.setattr(sc, "requests", requests_module)
+    return sc
+
+
+def make_core(sc):
+    return sc.SystemCore(SimpleNamespace())
+
+
+def test_check_twilio_api_success(monkeypatch):
+    class DummyService:
+        def __init__(self, *a, **k):
+            pass
+        def check(self, dry_run=True):
+            return {"success": True}
+
+    monkeypatch.setitem(sys.modules, "xcom.check_twilio_heartbeart_service",
+                        types.SimpleNamespace(CheckTwilioHeartbeartService=DummyService))
+    sc = load_core(monkeypatch)
+    core = make_core(sc)
+    assert core.check_twilio_api() == "ok"
+
+
+def test_check_twilio_api_failure(monkeypatch):
+    class DummyService:
+        def __init__(self, *a, **k):
+            pass
+        def check(self, dry_run=True):
+            return {"success": False, "error": "fail"}
+
+    monkeypatch.setitem(sys.modules, "xcom.check_twilio_heartbeart_service",
+                        types.SimpleNamespace(CheckTwilioHeartbeartService=DummyService))
+    sc = load_core(monkeypatch)
+    core = make_core(sc)
+    assert core.check_twilio_api() == "fail"
+
+
+def test_check_chatgpt_success(monkeypatch):
+    class DummyClient:
+        def __init__(self, api_key=None):
+            self.chat = types.SimpleNamespace(completions=types.SimpleNamespace(create=lambda *a, **k: None))
+
+    monkeypatch.setenv("OPENAI_API_KEY", "key")
+    monkeypatch.setitem(sys.modules, "openai", types.SimpleNamespace(OpenAI=DummyClient))
+    sc = load_core(monkeypatch)
+    core = make_core(sc)
+    assert core.check_chatgpt() == "ok"
+
+
+def test_check_chatgpt_no_key(monkeypatch):
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.delenv("OPEN_AI_KEY", raising=False)
+    sc = load_core(monkeypatch)
+    core = make_core(sc)
+    assert core.check_chatgpt() == "missing api key"
+
+
+def test_check_jupiter_success(monkeypatch):
+    class DummyResp:
+        def raise_for_status(self):
+            pass
+    class Requests:
+        def get(self, url, timeout=None):
+            return DummyResp()
+    sc = load_core(monkeypatch, Requests())
+    core = make_core(sc)
+    assert core.check_jupiter() == "ok"
+
+
+def test_check_jupiter_error(monkeypatch):
+    class Requests:
+        def get(self, url, timeout=None):
+            raise Exception("boom")
+    sc = load_core(monkeypatch, Requests())
+    core = make_core(sc)
+    assert core.check_jupiter() == "boom"


### PR DESCRIPTION
## Summary
- extend SystemCore with Twilio, ChatGPT, and Jupiter connectivity tests
- cover connectivity methods with new unit tests

## Testing
- `pytest -q`