### PR TITLE
Implement API status routes

### DIFF
--- a/system/system_core.py
+++ b/system/system_core.py
@@ -129,3 +129,65 @@ class SystemCore:
         except Exception as e:
             self.log.error(f"Failed to get active profile name: {e}", source="SystemCore")
             return ""
+
+    # === API Health Checks ===
+    def check_chatgpt(self) -> dict:
+        """Verify connectivity to the ChatGPT API."""
+        api_key = os.getenv("OPENAI_API_KEY") or os.getenv("OPEN_AI_KEY")
+        if not api_key:
+            return {"success": False, "error": "missing api key"}
+        try:  # pragma: no cover - openai optional
+            from openai import OpenAI
+
+            client = OpenAI(api_key=api_key)
+            client.chat.completions.create(
+                model="gpt-3.5-turbo",
+                messages=[{"role": "user", "content": "ping"}],
+            )
+            return {"success": True}
+        except Exception as exc:  # pragma: no cover - network dependent
+            self.log.error(f"ChatGPT check failed: {exc}", source="SystemCore")
+            return {"success": False, "error": str(exc)}
+
+    def check_twilio(self) -> dict:
+        """Verify connectivity to the Twilio API."""
+        try:
+            from xcom.check_twilio_heartbeart_service import CheckTwilioHeartbeartService
+
+            result = CheckTwilioHeartbeartService({}).check(dry_run=True)
+            if result.get("success"):
+                return {"success": True}
+            return {"success": False, "error": result.get("error")}
+        except Exception as exc:  # pragma: no cover - network dependent
+            self.log.error(f"Twilio check failed: {exc}", source="SystemCore")
+            return {"success": False, "error": str(exc)}
+
+    def check_jupiter(self) -> dict:
+        """Verify connectivity to the Jupiter API."""
+        try:
+            import requests
+            from core.constants import JUPITER_API_BASE
+
+            url = f"{JUPITER_API_BASE.rstrip('/')}/ping"
+            res = requests.get(url, timeout=5)
+            if res.status_code == 200:
+                return {"success": True}
+            return {"success": False, "error": f"status {res.status_code}"}
+        except Exception as exc:  # pragma: no cover - network dependent
+            self.log.error(f"Jupiter check failed: {exc}", source="SystemCore")
+            return {"success": False, "error": str(exc)}
+
+    def check_placeholder(self) -> dict:
+        """Placeholder API check that always succeeds."""
+        return {"success": True}
+
+    def check_api(self, api_name: str) -> dict:
+        """Dispatch to a specific API health check based on ``api_name``."""
+        name = (api_name or "").lower()
+        if name == "twilio":
+            return self.check_twilio()
+        if name == "chatgpt":
+            return self.check_chatgpt()
+        if name == "jupiter":
+            return self.check_jupiter()
+        return self.check_placeholder()

--- a/tests/test_system_api_routes.py
+++ b/tests/test_system_api_routes.py
@@ -1,0 +1,57 @@
+import types
+import importlib
+import pytest
+
+flask = importlib.import_module("flask")
+if not getattr(flask, "Flask", None):
+    pytest.skip("Flask not available", allow_module_level=True)
+from flask import Flask
+
+from app.system_bp import system_bp
+
+
+@pytest.fixture
+def make_app(monkeypatch):
+    def _make(core):
+        app = Flask(__name__)
+        app.config["TESTING"] = True
+        app.register_blueprint(system_bp, url_prefix="/system")
+        monkeypatch.setattr("app.system_bp.get_core", lambda: core)
+        return app
+    return _make
+
+
+def test_api_check_route_calls_core(monkeypatch, make_app):
+    called = {}
+
+    def check_api(name):
+        called["name"] = name
+        return {"result": True}
+
+    core = types.SimpleNamespace(check_api=check_api)
+    app = make_app(core)
+    with app.test_client() as client:
+        resp = client.get("/system/api/check/twilio")
+        assert resp.status_code == 200
+        assert resp.get_json() == {"result": True}
+        assert called["name"] == "twilio"
+
+
+def test_xcom_api_status_aggregates(monkeypatch, make_app):
+    core = types.SimpleNamespace(
+        check_twilio=lambda: {"success": True},
+        check_chatgpt=lambda: {"success": True},
+        check_jupiter=lambda: {"success": False, "error": "boom"},
+        check_placeholder=lambda: {"success": True},
+    )
+    app = make_app(core)
+    with app.test_client() as client:
+        resp = client.get("/system/xcom_api_status")
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert data == {
+            "twilio": "ok",
+            "chatgpt": "ok",
+            "jupiter": "error: boom",
+            "placeholder": "ok",
+        }


### PR DESCRIPTION
## Summary
- add health check methods in `SystemCore`
- implement `/api/check/<api_name>` endpoint
- expand `/xcom_api_status` to check multiple APIs
- test system API routes

## Testing
- `pytest -q`
