### PR TITLE
Add oracle icons to dashboard panels

### DIFF
--- a/static/css/sonic_dashboard.css
+++ b/static/css/sonic_dashboard.css
@@ -262,6 +262,15 @@
   position: static;
 }
 
+/* Oracle icon positioned in panel corner */
+.oracle-icon {
+  position: absolute;
+  top: 0.4rem;
+  right: 0.6rem;
+  cursor: pointer;
+  font-size: 1.3rem;
+}
+
 /* ─────────────────────────────────────────────── */
 /* Layout Modes: Wide, Fitted, Mobile */
 body.wide-mode .sonic-section-container {

--- a/static/js/dashboard_oracle.js
+++ b/static/js/dashboard_oracle.js
@@ -1,0 +1,32 @@
+// === dashboard_oracle.js ===
+// Add click handlers for oracle icons on the dashboard panels
+
+document.addEventListener('DOMContentLoaded', () => {
+  document.querySelectorAll('.oracle-icon').forEach(icon => {
+    icon.addEventListener('click', () => {
+      const topic = icon.dataset.topic;
+      if (!topic) return;
+      fetch(`/gpt/oracle/${topic}`)
+        .then(res => res.json())
+        .then(data => {
+          const reply = data.reply || data.error || 'No response';
+          speakResponse(reply);
+        })
+        .catch(err => console.error('Oracle query failed:', err));
+    });
+  });
+});
+
+function speakResponse(text) {
+  if (!window.speechSynthesis) return;
+  speechSynthesis.cancel();
+  const utter = new SpeechSynthesisUtterance(text);
+  utter.pitch = 1.1;
+  utter.rate = 0.92;
+  utter.volume = 1;
+  const voices = speechSynthesis.getVoices();
+  const voice = voices.find(v => v.name === 'Google UK English Female') ||
+                voices.find(v => v.lang && v.lang.includes('en'));
+  if (voice) utter.voice = voice;
+  speechSynthesis.speak(utter);
+}

--- a/templates/liquidation_bars.html
+++ b/templates/liquidation_bars.html
@@ -1,4 +1,6 @@
-<div class="section-title">Liquidation Bars</div>
+<div class="section-title">Liquidation Bars
+  <span class="oracle-icon" data-topic="alerts" title="Ask the Oracle">🔮</span>
+</div>
 
   {% if liquidation_positions %}
     {% for pos in liquidation_positions %}

--- a/templates/monitor_cards.html
+++ b/templates/monitor_cards.html
@@ -1,4 +1,6 @@
-<div class="section-title">Monitor</div>
+<div class="section-title">Monitor
+  <span class="oracle-icon" data-topic="system" title="Ask the Oracle">🔮</span>
+</div>
 <div class="card-flex">
     {% for item in monitor_items %}
       <div class="flip-card">

--- a/templates/portfolio_cards.html
+++ b/templates/portfolio_cards.html
@@ -1,4 +1,6 @@
-<div class="section-title">Portfolio</div>
+<div class="section-title">Portfolio
+  <span class="oracle-icon" data-topic="portfolio" title="Ask the Oracle">🔮</span>
+</div>
 <div class="card-flex">
     {% set title_to_key = {
         'value': 'total_value',

--- a/templates/positions_table.html
+++ b/templates/positions_table.html
@@ -1,5 +1,7 @@
 <link rel="stylesheet" href="{{ url_for('static', filename='css/dashboard_middle.css') }}">
-<div class="section-title">Positions</div>
+<div class="section-title">Positions
+  <span class="oracle-icon" data-topic="prices" title="Ask the Oracle">🔮</span>
+</div>
 <div class="positions-table-wrapper">
   <table class="positions-table">
     <thead>

--- a/templates/sonic_dashboard.html
+++ b/templates/sonic_dashboard.html
@@ -43,6 +43,7 @@
     window.sizeData = {{ size_composition | tojson }};
   </script>
   <script src="{{ url_for('static', filename='js/dashboard_bottom.js') }}"></script>
+  <script src="{{ url_for('static', filename='js/dashboard_oracle.js') }}"></script>
   <script src="{{ url_for('static', filename='js/size_pie.js') }}"></script>
   <script src="{{ url_for('static', filename='js/debug_outlines.js') }}"></script>
   <script src="{{ url_for('static', filename='js/dashboard_parallax.js') }}"></script>


### PR DESCRIPTION
## Summary
- add clickable 🔮 icons for Oracle queries on dashboard panels
- play Oracle responses using speech synthesis with Google UK English Female voice

## Testing
- `pytest -q`