### PR TITLE
Require DB alert config

### DIFF
--- a/alert_core/alert_core.py
+++ b/alert_core/alert_core.py
@@ -11,9 +11,13 @@ from core.core_imports import log
 class AlertCore:
     def __init__(self, data_locker, config_loader=None):
         self.data_locker = data_locker
-        self.config_loader = config_loader or (
-            lambda: self.data_locker.system.get_var("alert_limits") or {}
-        )
+        def strict_config_loader():
+            config = self.data_locker.system.get_var("alert_limits")
+            if config is None:
+                raise RuntimeError("🛑 No alert_limits config found in DB")
+            return config
+
+        self.config_loader = config_loader or strict_config_loader
         self.repo = AlertStore(data_locker, self.config_loader)
         self.enricher = AlertEnrichmentService(data_locker)
         threshold_service = ThresholdService(data_locker.db)

--- a/alert_core/alert_store.py
+++ b/alert_core/alert_store.py
@@ -57,9 +57,13 @@ class AlertStore:
         if config_loader:
             self.config_loader = config_loader
         else:
-            self.config_loader = (
-                lambda: self.data_locker.system.get_var("alert_limits") or {}
-            )
+            def strict_config_loader():
+                config = self.data_locker.system.get_var("alert_limits")
+                if config is None:
+                    raise RuntimeError("🛑 No alert_limits config found in DB")
+                return config
+
+            self.config_loader = strict_config_loader
 
     @staticmethod
     def initialize_alert_data(alert_data: dict = None) -> dict:

--- a/alert_core/alert_utils.py
+++ b/alert_core/alert_utils.py
@@ -161,7 +161,24 @@ def log_alert_summary(alert):
         alert_class = alert.get("alert_class")
         trigger_value = alert.get("trigger_value")
 
-    log.info(
-        f"📦 Alert Created → 🧭 Class: {alert_class} | 🏷️ Type: {alert_type} | 🎯 Trigger: {trigger_value}",
-        source="CreateAlert"
+        log.info(
+            f"📦 Alert Created → 🧭 Class: {alert_class} | 🏷️ Type: {alert_type} | 🎯 Trigger: {trigger_value}",
+            source="CreateAlert"
+        )
+
+
+def load_alert_limits_from_file(data_locker):
+    """Manually import alert_limits from disk into the database."""
+    from config.config_loader import load_config
+    from core.constants import ALERT_LIMITS_PATH
+
+    config = load_config(str(ALERT_LIMITS_PATH))
+    if not config:
+        raise RuntimeError("🛑 Config file is invalid or empty")
+
+    data_locker.system.set_var("alert_limits", config)
+    log.success(
+        "✅ Loaded alert_limits config into DB from file",
+        source="ConfigImport",
     )
+    return config


### PR DESCRIPTION
## Summary
- disallow AlertCore and AlertStore from using a JSON fallback
- enforce DB config for Cyclone startup
- provide admin helper to import alert limits from file

## Testing
- `pytest -q`