### PR TITLE
Add API check dispatcher

### DIFF
--- a/system/system_core.py
+++ b/system/system_core.py
@@ -190,3 +190,19 @@ class SystemCore:
         except Exception as exc:  # pragma: no cover - network dependent
             self.log.error(f"GitHub API check failed: {exc}", source="SystemCore")
             return str(exc)
+
+    def check_api(self, api_name: str) -> dict:
+        """Dispatch to the appropriate API check based on ``api_name``."""
+        checks = {
+            "twilio": self.check_twilio_api,
+            "chatgpt": self.check_chatgpt,
+            "jupiter": self.check_jupiter,
+            "github": self.check_github,
+        }
+
+        check_func = checks.get(api_name.lower())
+        if not check_func:
+            return {"status": "unknown api"}
+
+        result = check_func()
+        return {"status": result}

--- a/tests/test_system_core_connectivity.py
+++ b/tests/test_system_core_connectivity.py
@@ -109,3 +109,28 @@ def test_check_github_error(monkeypatch):
     sc = load_core(monkeypatch, Requests())
     core = make_core(sc)
     assert core.check_github() == "boom"
+
+
+def test_check_api_dispatch(monkeypatch):
+    sc = load_core(monkeypatch)
+    core = make_core(sc)
+
+    called = {}
+
+    def dummy():
+        called["name"] = True
+        return "ok"
+
+    monkeypatch.setattr(core, "check_twilio_api", dummy)
+
+    result = core.check_api("twilio")
+
+    assert result == {"status": "ok"}
+    assert called["name"] is True
+
+
+def test_check_api_unknown(monkeypatch):
+    sc = load_core(monkeypatch)
+    core = make_core(sc)
+
+    assert core.check_api("doesnotexist") == {"status": "unknown api"}


### PR DESCRIPTION
## Summary
- add a `check_api` dispatcher to `SystemCore`
- test dispatcher logic in SystemCore connectivity tests

## Testing
- `pytest -q`