### PR TITLE
Remove blur from Oracle UI background

### DIFF
--- a/templates/oracle_gpt.html
+++ b/templates/oracle_gpt.html
@@ -23,7 +23,7 @@
     align-items: center;
     justify-content: center;
     min-height: 100vh;
-    backdrop-filter: blur(4px);
+    backdrop-filter: none;
     position: relative;
   }
   .oracle-panel {


### PR DESCRIPTION
## Summary
- make the Oracle UI background sharp by removing the CSS blur effect

## Testing
- `pytest -q`