### PR TITLE
Fix duplicate set_last_update_times

### DIFF
--- a/app/prices_bp.py
+++ b/app/prices_bp.py
@@ -174,10 +174,10 @@ def update_prices_route():
         asyncio.run(pm.update_prices())
         dl = get_locker()
         now = datetime.now()
-        dl.set_last_update_times(
-            prices_dt=now,
-            prices_source=source
-        )
+        dl.set_last_update_times({
+            "last_update_time_prices": now.isoformat(),
+            "last_update_prices_source": source
+        })
         return jsonify({
             "status": "ok",
             "message": "Prices updated successfully",

--- a/data/data_locker.py
+++ b/data/data_locker.py
@@ -297,9 +297,6 @@ class DataLocker:
     def read_positions(self):
         return self.positions.get_all_positions()
 
-    def set_last_update_times(self, prices_dt, prices_source):
-        self.system.set_last_update_times(prices_dt, prices_source)
-
     def close(self):
         self.db.close()  # Hey
         log.debug("DataLocker shutdown complete.", source="DataLocker")


### PR DESCRIPTION
## Summary
- remove obsolete set_last_update_times method
- update prices route to use dict-based API

## Testing
- `pytest -q`