### PR TITLE
Add DeathNail alert threshold

### DIFF
--- a/alert_thresholds.json
+++ b/alert_thresholds.json
@@ -163,5 +163,20 @@
     "low_notify": "",
     "medium_notify": "",
     "high_notify": ""
+  },
+  {
+    "id": "262d71f3-88e7-4a25-92e5-4fbb3c17b761",
+    "alert_type": "DeathNail",
+    "alert_class": "System",
+    "metric_key": "death_nail",
+    "condition": "ABOVE",
+    "low": 0.0,
+    "medium": 0.0,
+    "high": 1.0,
+    "enabled": 0,
+    "last_modified": "2025-05-25T21:11:08.690000+00:00",
+    "low_notify": "",
+    "medium_notify": "",
+    "high_notify": ""
   }
 ]

--- a/data/threshold_seeder.py
+++ b/data/threshold_seeder.py
@@ -112,6 +112,8 @@ class AlertThresholdSeeder:
 
             # === Market Metrics
             ("PriceThreshold", "Market", "current_price", 20000, 30000, 40000, "ABOVE"),
+            # === System Alerts
+            ("DeathNail", "System", "death_nail", 0, 0, 1, "ABOVE"),
         ]
 
         created = 0


### PR DESCRIPTION
## Summary
- add DeathNail system alert threshold definition
- include DeathNail alert in default threshold seeder

## Testing
- `pytest -q`