### PR TITLE
Expand system context for GPT Oracle

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,10 @@ curl "http://localhost:5000/gpt/oracle/portfolio?strategy=none"
 Replace `portfolio` with any other topic to receive a short summary. Use the
 `strategy` query parameter to apply a named strategy (defaults to `none`).
 
+System queries now include the latest update timestamps along with recent
+`death_log.txt` entries and any system alerts so GPT can report operational
+issues.
+
 ### Personas
 
 Oracle responses can adopt different tones. Specify a `persona` with the

--- a/data/data_locker.py
+++ b/data/data_locker.py
@@ -314,6 +314,30 @@ class DataLocker:
         except Exception:
             return {}
 
+    def get_death_log_entries(self, limit: int = 20) -> list:
+        """Return the most recent entries from the death log file."""
+        path = os.path.join(BASE_DIR, "death_log.txt")
+        try:
+            if not os.path.exists(path):
+                return []
+            with open(path, "r", encoding="utf-8") as f:
+                lines = [line.strip() for line in f.readlines() if line.strip()]
+            entries = [json.loads(l) for l in lines]
+            return entries[-limit:]
+        except Exception as e:
+            log.error(f"❌ Failed to read death log: {e}", source="DataLocker")
+            return []
+
+    def get_system_alerts(self, limit: int = 20) -> list:
+        """Return recent alerts belonging to the System class."""
+        try:
+            alerts = self.alerts.get_all_alerts()
+            system_alerts = [a for a in alerts if a.get("alert_class") == "System"]
+            return system_alerts[:limit]
+        except Exception as e:
+            log.error(f"❌ Failed to retrieve system alerts: {e}", source="DataLocker")
+            return []
+
     def insert_or_update_price(self, asset_type, price, source="PriceMonitor"):
         from uuid import uuid4
         from datetime import datetime

--- a/oracle_core/oracle_core_spec.md
+++ b/oracle_core/oracle_core_spec.md
@@ -56,4 +56,4 @@ Each handler (`PortfolioTopicHandler`, `AlertsTopicHandler`, `PricesTopicHandler
 - `fetch_portfolio()` → latest portfolio snapshot
 - `fetch_alerts()` → recent alerts
 - `fetch_prices()` → recent prices
-- `fetch_system()` → last update timestamps
+- `fetch_system()` → `{"last_update_times": ..., "death_log": [...], "system_alerts": [...]}`

--- a/oracle_core/oracle_data_service.py
+++ b/oracle_core/oracle_data_service.py
@@ -13,8 +13,18 @@ class OracleDataService:
     def fetch_prices(self):
         return self.dl.prices.get_all_prices()[:20]
 
+    def fetch_death_log(self):
+        return self.dl.get_death_log_entries()
+
+    def fetch_system_alerts(self):
+        return self.dl.get_system_alerts()
+
     def fetch_system(self):
-        return self.dl.get_last_update_times()
+        return {
+            "last_update_times": self.dl.get_last_update_times(),
+            "death_log": self.fetch_death_log(),
+            "system_alerts": self.fetch_system_alerts(),
+        }
 
     def get_topic_data(self, topic: str):
         if topic == "portfolio":

--- a/tests/test_oracle_data_service.py
+++ b/tests/test_oracle_data_service.py
@@ -1,0 +1,32 @@
+import importlib.util
+from pathlib import Path
+
+
+def load_module():
+    base = Path(__file__).resolve().parents[1]
+    path = base / "oracle_core" / "oracle_data_service.py"
+    spec = importlib.util.spec_from_file_location("oracle_core.oracle_data_service", path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec and spec.loader
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_fetch_system_includes_new_fields():
+    mod = load_module()
+
+    class DummyDL:
+        def get_last_update_times(self):
+            return {"t": 1}
+
+        def get_death_log_entries(self, limit=20):
+            return ["d1"]
+
+        def get_system_alerts(self, limit=20):
+            return ["a1"]
+
+    ods = mod.OracleDataService(DummyDL())
+    data = ods.fetch_system()
+    assert data["last_update_times"] == {"t": 1}
+    assert data["death_log"] == ["d1"]
+    assert data["system_alerts"] == ["a1"]


### PR DESCRIPTION
## Summary
- support reading death logs and system alerts in `DataLocker`
- expose new helpers via `OracleDataService`
- document new system context
- test that the expanded system data is returned

## Testing
- `pytest -q`