### PR TITLE
Implement Twilio SMS alerts

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,6 +12,8 @@ TWILIO_AUTH_TOKEN=your_auth_token_here
 TWILIO_FLOW_SID=your_flow_sid_here
 TWILIO_FROM_PHONE=+1987654321
 TWILIO_TO_PHONE=+1234567890
+TWILIO_FROM_NUMBER=+1987654321
+ALERT_SMS_NUMBER=+1234567890
 # Optional Jupiter endpoint override
 JUPITER_API_BASE=https://perps-api.jup.ag
 # OpenAI API key for ChatGPT integration

--- a/alert_core/alert_core.py
+++ b/alert_core/alert_core.py
@@ -6,6 +6,8 @@ from alert_core.alert_enrichment_service import AlertEnrichmentService
 from alert_core.alert_evaluation_service import AlertEvaluationService
 from alert_core.threshold_service import ThresholdService
 from alert_core.alert_store import AlertStore
+from alert_core.alert_notifier import AlertNotifier
+from data.alert import NotificationType
 from core.core_imports import log
 
 class AlertCore:
@@ -52,6 +54,16 @@ class AlertCore:
                 source="AlertCore",
                 payload={"id": evaluated.id, "level": evaluated.level, "value": evaluated.evaluated_value}
             )
+
+            if evaluated.notification_type == NotificationType.SMS:
+                try:
+                    notifier = AlertNotifier(self.data_locker)
+                    notifier.notify(evaluated)
+                except Exception as notify_err:
+                    log.error(
+                        f"Failed to send SMS notification: {notify_err}",
+                        source="AlertCore",
+                    )
 
             return evaluated
         except Exception as e:

--- a/alert_core/alert_notifier.py
+++ b/alert_core/alert_notifier.py
@@ -1,0 +1,30 @@
+from data.alert import NotificationType
+from notifications.twilio_sms_sender import TwilioSMSSender
+from core.logging import log
+import os
+
+
+class AlertNotifier:
+    """Dispatch notifications for evaluated alerts."""
+
+    def __init__(self, data_locker):
+        self.data_locker = data_locker
+        self.sms_sender = TwilioSMSSender()
+
+    def notify(self, alert):
+        """Send notifications based on alert configuration."""
+        if alert.notification_type == NotificationType.SMS:
+            phone_number = (
+                self.data_locker.system.get_var("alert_sms_number")
+                or os.getenv("ALERT_SMS_NUMBER")
+            )
+            message = (
+                f"🚨 Alert Triggered: {alert.description}\n"
+                f"Level: {alert.level}\n"
+                f"Value: {alert.evaluated_value}"
+            )
+            if not phone_number:
+                log.error("No alert_sms_number configured", source="AlertNotifier")
+                return False
+            return self.sms_sender.send_sms(str(phone_number), message)
+        return False

--- a/notifications/twilio_sms_sender.py
+++ b/notifications/twilio_sms_sender.py
@@ -1,0 +1,31 @@
+from twilio.rest import Client
+import os
+from core.logging import log
+
+class TwilioSMSSender:
+    """Simple wrapper around the Twilio REST client for SMS."""
+
+    def __init__(self, account_sid=None, auth_token=None, from_number=None):
+        self.account_sid = account_sid or os.getenv("TWILIO_ACCOUNT_SID")
+        self.auth_token = auth_token or os.getenv("TWILIO_AUTH_TOKEN")
+        self.from_number = from_number or os.getenv("TWILIO_FROM_NUMBER")
+        self.client = Client(self.account_sid, self.auth_token)
+
+    def send_sms(self, to_number: str, message: str) -> bool:
+        """Send an SMS message via Twilio."""
+        try:
+            if not all([self.account_sid, self.auth_token, self.from_number, to_number]):
+                log.error("Missing Twilio SMS configuration", source="TwilioSMSSender")
+                return False
+
+            msg = self.client.messages.create(body=message, from_=self.from_number, to=to_number)
+            log.info(
+                "✅ SMS sent",
+                source="TwilioSMSSender",
+                payload={"sid": getattr(msg, "sid", None)}
+            )
+            return True
+        except Exception as e:
+            log.error(f"❌ Failed to send SMS: {e}", source="TwilioSMSSender")
+            return False
+

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -71,7 +71,22 @@ sys.modules.setdefault("requests", requests_stub)
 twilio_stub = types.ModuleType("twilio")
 sys.modules.setdefault("twilio", twilio_stub)
 twilio_rest_stub = types.ModuleType("twilio.rest")
-twilio_rest_stub.Client = object
+
+class DummyTwilioMessage:
+    def __init__(self, sid="SMxxxx"):
+        self.sid = sid
+
+
+class DummyTwilioClient:
+    def __init__(self, *a, **k):
+        class Messages:
+            @staticmethod
+            def create(body=None, from_=None, to=None):
+                return DummyTwilioMessage()
+
+        self.messages = Messages()
+
+twilio_rest_stub.Client = DummyTwilioClient
 sys.modules.setdefault("twilio.rest", twilio_rest_stub)
 twilio_voice_stub = types.ModuleType("twilio.twiml.voice_response")
 twilio_voice_stub.VoiceResponse = object

--- a/tests/test_twilio_sms_sender.py
+++ b/tests/test_twilio_sms_sender.py
@@ -1,0 +1,10 @@
+from notifications.twilio_sms_sender import TwilioSMSSender
+
+
+def test_twilio_sms_sender(monkeypatch):
+    monkeypatch.setenv("TWILIO_ACCOUNT_SID", "sid")
+    monkeypatch.setenv("TWILIO_AUTH_TOKEN", "token")
+    monkeypatch.setenv("TWILIO_FROM_NUMBER", "+10000000000")
+
+    sender = TwilioSMSSender()
+    assert sender.send_sms("+15555555555", "test") is True


### PR DESCRIPTION
## Summary
- add `TwilioSMSSender` helper in new `notifications` package
- create `AlertNotifier` for dispatching SMS alerts
- send SMS in `AlertCore.evaluate_alert`
- update environment example with SMS settings
- stub Twilio REST client for tests
- add unit test for `TwilioSMSSender`

## Testing
- `pytest -q`