### PR TITLE
Remove PublicKey conversion in balance services

### DIFF
--- a/tests/test_blockchain_balance_service.py
+++ b/tests/test_blockchain_balance_service.py
@@ -25,3 +25,15 @@ def test_get_balance_solana(monkeypatch):
     bal = service.get_balance("SoLAddress")
     assert bal == 2.0
     mock_client.get_balance.assert_called()
+
+
+def test_solana_client_called_with_str(monkeypatch):
+    service = svc.BlockchainBalanceService()
+    mock_client = MagicMock()
+    monkeypatch.setattr(service, "_sol", mock_client)
+    monkeypatch.setattr(svc, "Confirmed", None)
+
+    service.get_balance("Addr")
+    args, kwargs = mock_client.get_balance.call_args
+    assert args[0] == "Addr"
+    assert isinstance(args[0], str)

--- a/wallets/blockchain_balance_service.py
+++ b/wallets/blockchain_balance_service.py
@@ -16,11 +16,9 @@ except Exception:  # pragma: no cover - optional dependency
 
 try:
     from solana.rpc.api import Client
-    from solana.publickey import PublicKey
     from solana.rpc.commitment import Confirmed
 except Exception:  # pragma: no cover - optional dependency
     Client = None  # type: ignore
-    PublicKey = None  # type: ignore
     Confirmed = None  # type: ignore
 
 from core.logging import log
@@ -60,11 +58,10 @@ class BlockchainBalanceService:
             log.error("solana library unavailable", source="BlockchainBalanceService")
             return None
         try:
-            key = PublicKey(address) if PublicKey else address
             kwargs = {}
             if Confirmed:
                 kwargs["commitment"] = Confirmed
-            resp = self._sol.get_balance(key, **kwargs)
+            resp = self._sol.get_balance(str(address), **kwargs)
             lamports = resp.get("result", {}).get("value")
             if lamports is not None:
                 return lamports / LAMPORTS_PER_SOL

--- a/wallets/check_wallet_balance_service.py
+++ b/wallets/check_wallet_balance_service.py
@@ -11,11 +11,9 @@ except Exception:  # pragma: no cover - optional dependency
 
 try:
     from solana.rpc.api import Client
-    from solana.publickey import PublicKey
     from solana.rpc.commitment import Confirmed
 except Exception:  # pragma: no cover - optional dependency
     Client = None  # type: ignore
-    PublicKey = None  # type: ignore
     Confirmed = None  # type: ignore
 
 from core.logging import log
@@ -58,11 +56,10 @@ class CheckWalletBalanceService:
             log.error("solana library unavailable", source="WalletBalanceSvc")
             return None
         try:
-            key = PublicKey(address) if PublicKey else address
             kwargs = {}
             if Confirmed:
                 kwargs["commitment"] = Confirmed
-            resp = self._sol.get_balance(key, **kwargs)
+            resp = self._sol.get_balance(str(address), **kwargs)
             lamports = resp.get("result", {}).get("value")
             if lamports is not None:
                 return lamports / LAMPORTS_PER_SOL


### PR DESCRIPTION
## Summary
- stop converting Solana addresses to `PublicKey` objects before fetching balances
- update both balance services to pass string addresses directly
- test that the solana client receives a string address

## Testing
- `pytest -q tests/test_blockchain_balance_service.py`