### PR TITLE
Fix solana wallet balance lookup

### DIFF
--- a/tests/test_blockchain_balance_service.py
+++ b/tests/test_blockchain_balance_service.py
@@ -21,19 +21,20 @@ def test_get_balance_solana(monkeypatch):
     mock_client = MagicMock()
     mock_client.get_balance.return_value = {"result": {"value": 2 * svc.LAMPORTS_PER_SOL}}
     monkeypatch.setattr(service, "_sol", mock_client)
+    monkeypatch.setattr(svc, "PublicKey", lambda x: x)
 
     bal = service.get_balance("SoLAddress")
     assert bal == 2.0
     mock_client.get_balance.assert_called()
 
 
-def test_solana_client_called_with_str(monkeypatch):
+def test_solana_client_called_with_public_key(monkeypatch):
     service = svc.BlockchainBalanceService()
     mock_client = MagicMock()
     monkeypatch.setattr(service, "_sol", mock_client)
     monkeypatch.setattr(svc, "Confirmed", None)
+    monkeypatch.setattr(svc, "PublicKey", lambda x: f"PK:{x}")
 
     service.get_balance("Addr")
     args, kwargs = mock_client.get_balance.call_args
-    assert args[0] == "Addr"
-    assert isinstance(args[0], str)
+    assert args[0] == "PK:Addr"

--- a/wallets/blockchain_balance_service.py
+++ b/wallets/blockchain_balance_service.py
@@ -17,9 +17,11 @@ except Exception:  # pragma: no cover - optional dependency
 try:
     from solana.rpc.api import Client
     from solana.rpc.commitment import Confirmed
+    from solana.publickey import PublicKey
 except Exception:  # pragma: no cover - optional dependency
     Client = None  # type: ignore
     Confirmed = None  # type: ignore
+    PublicKey = object  # type: ignore
 
 from core.logging import log
 
@@ -61,7 +63,7 @@ class BlockchainBalanceService:
             kwargs = {}
             if Confirmed:
                 kwargs["commitment"] = Confirmed
-            resp = self._sol.get_balance(str(address), **kwargs)
+            resp = self._sol.get_balance(PublicKey(address), **kwargs)
             lamports = resp.get("result", {}).get("value")
             if lamports is not None:
                 return lamports / LAMPORTS_PER_SOL

--- a/wallets/check_wallet_balance_service.py
+++ b/wallets/check_wallet_balance_service.py
@@ -12,9 +12,11 @@ except Exception:  # pragma: no cover - optional dependency
 try:
     from solana.rpc.api import Client
     from solana.rpc.commitment import Confirmed
+    from solana.publickey import PublicKey
 except Exception:  # pragma: no cover - optional dependency
     Client = None  # type: ignore
     Confirmed = None  # type: ignore
+    PublicKey = object  # type: ignore
 
 from core.logging import log
 
@@ -59,7 +61,7 @@ class CheckWalletBalanceService:
             kwargs = {}
             if Confirmed:
                 kwargs["commitment"] = Confirmed
-            resp = self._sol.get_balance(str(address), **kwargs)
+            resp = self._sol.get_balance(PublicKey(address), **kwargs)
             lamports = resp.get("result", {}).get("value")
             if lamports is not None:
                 return lamports / LAMPORTS_PER_SOL


### PR DESCRIPTION
## Summary
- fix solana balance lookups by converting address strings to `PublicKey`
- adjust blockchain balance service tests for new behaviour

## Testing
- `pytest -q`