### PR TITLE
Fix Solana balance fetch with solders Pubkey

### DIFF
--- a/tests/test_blockchain_balance_service.py
+++ b/tests/test_blockchain_balance_service.py
@@ -21,7 +21,7 @@ def test_get_balance_solana(monkeypatch):
     mock_client = MagicMock()
     mock_client.get_balance.return_value = {"result": {"value": 2 * svc.LAMPORTS_PER_SOL}}
     monkeypatch.setattr(service, "_sol", mock_client)
-    monkeypatch.setattr(svc, "PublicKey", lambda x: x)
+    monkeypatch.setattr(svc, "Pubkey", types.SimpleNamespace(from_string=lambda x: x))
 
     bal = service.get_balance("SoLAddress")
     assert bal == 2.0
@@ -33,7 +33,7 @@ def test_solana_client_called_with_public_key(monkeypatch):
     mock_client = MagicMock()
     monkeypatch.setattr(service, "_sol", mock_client)
     monkeypatch.setattr(svc, "Confirmed", None)
-    monkeypatch.setattr(svc, "PublicKey", lambda x: f"PK:{x}")
+    monkeypatch.setattr(svc, "Pubkey", types.SimpleNamespace(from_string=lambda x: f"PK:{x}"))
 
     service.get_balance("Addr")
     args, kwargs = mock_client.get_balance.call_args

--- a/wallets/blockchain_balance_service.py
+++ b/wallets/blockchain_balance_service.py
@@ -17,11 +17,13 @@ except Exception:  # pragma: no cover - optional dependency
 try:
     from solana.rpc.api import Client
     from solana.rpc.commitment import Confirmed
-    from solana.publickey import PublicKey
-except Exception:  # pragma: no cover - optional dependency
+    from solders.pubkey import Pubkey
+except Exception as e:  # pragma: no cover - optional dependency
+    import sys
+    print("❌ Failed to import solana/solders:", e, file=sys.stderr)
     Client = None  # type: ignore
     Confirmed = None  # type: ignore
-    PublicKey = object  # type: ignore
+    Pubkey = object  # type: ignore
 
 from core.logging import log
 
@@ -63,7 +65,8 @@ class BlockchainBalanceService:
             kwargs = {}
             if Confirmed:
                 kwargs["commitment"] = Confirmed
-            resp = self._sol.get_balance(PublicKey(address), **kwargs)
+            clean_address = address.strip()
+            resp = self._sol.get_balance(Pubkey.from_string(clean_address), **kwargs)
             lamports = resp.get("result", {}).get("value")
             if lamports is not None:
                 return lamports / LAMPORTS_PER_SOL

--- a/wallets/check_wallet_balance_service.py
+++ b/wallets/check_wallet_balance_service.py
@@ -12,11 +12,13 @@ except Exception:  # pragma: no cover - optional dependency
 try:
     from solana.rpc.api import Client
     from solana.rpc.commitment import Confirmed
-    from solana.publickey import PublicKey
-except Exception:  # pragma: no cover - optional dependency
+    from solders.pubkey import Pubkey
+except Exception as e:  # pragma: no cover - optional dependency
+    import sys
+    print("❌ Failed to import solana/solders:", e, file=sys.stderr)
     Client = None  # type: ignore
     Confirmed = None  # type: ignore
-    PublicKey = object  # type: ignore
+    Pubkey = object  # type: ignore
 
 from core.logging import log
 
@@ -61,7 +63,8 @@ class CheckWalletBalanceService:
             kwargs = {}
             if Confirmed:
                 kwargs["commitment"] = Confirmed
-            resp = self._sol.get_balance(PublicKey(address), **kwargs)
+            clean_address = address.strip()
+            resp = self._sol.get_balance(Pubkey.from_string(clean_address), **kwargs)
             lamports = resp.get("result", {}).get("value")
             if lamports is not None:
                 return lamports / LAMPORTS_PER_SOL

--- a/wallets/wallet_core.py
+++ b/wallets/wallet_core.py
@@ -19,14 +19,16 @@ try:
     from solana.rpc.api import Client
     from solana.transaction import Transaction
     from solana.keypair import Keypair
-    from solana.publickey import PublicKey
+    from solders.pubkey import Pubkey
     from solana.rpc.commitment import Confirmed
     from solana.rpc.types import TxOpts
-except Exception:  # pragma: no cover - optional dependency
+except Exception as e:  # pragma: no cover - optional dependency
+    import sys
+    print("❌ Failed to import solana/solders:", e, file=sys.stderr)
     Client = None
     Transaction = object
     Keypair = object
-    PublicKey = object
+    Pubkey = object
     Confirmed = None
     TxOpts = object
 
@@ -86,7 +88,7 @@ class WalletCore:
             log.debug("fetch_balance skipped; solana client unavailable", source="WalletCore")
             return None
         try:
-            resp = self.client.get_balance(PublicKey(wallet.public_address), commitment=Confirmed)
+            resp = self.client.get_balance(Pubkey.from_string(wallet.public_address.strip()), commitment=Confirmed)
             lamports = resp.get("result", {}).get("value")
             if lamports is not None:
                 return lamports / LAMPORTS_PER_SOL


### PR DESCRIPTION
## Summary
- use `solders.Pubkey` instead of `solana.publickey.PublicKey`
- sanitize addresses before querying balances
- improve import error logging for Solana client
- adjust wallet core and services to new API
- update tests for Pubkey usage

## Testing
- `pytest -q tests/test_blockchain_balance_service.py`