### PR TITLE
Fix GetBalanceResp usage

### DIFF
--- a/tests/test_blockchain_balance_service.py
+++ b/tests/test_blockchain_balance_service.py
@@ -19,7 +19,7 @@ def test_get_balance_eth(monkeypatch):
 def test_get_balance_solana(monkeypatch):
     service = svc.BlockchainBalanceService()
     mock_client = MagicMock()
-    mock_client.get_balance.return_value = {"result": {"value": 2 * svc.LAMPORTS_PER_SOL}}
+    mock_client.get_balance.return_value = types.SimpleNamespace(value=2 * svc.LAMPORTS_PER_SOL)
     monkeypatch.setattr(service, "_sol", mock_client)
     monkeypatch.setattr(svc, "Pubkey", types.SimpleNamespace(from_string=lambda x: x))
 

--- a/wallets/blockchain_balance_service.py
+++ b/wallets/blockchain_balance_service.py
@@ -67,7 +67,7 @@ class BlockchainBalanceService:
                 kwargs["commitment"] = Confirmed
             clean_address = address.strip()
             resp = self._sol.get_balance(Pubkey.from_string(clean_address), **kwargs)
-            lamports = resp.get("result", {}).get("value")
+            lamports = resp.value
             if lamports is not None:
                 return lamports / LAMPORTS_PER_SOL
         except Exception as exc:  # pragma: no cover - network failures

--- a/wallets/check_wallet_balance_service.py
+++ b/wallets/check_wallet_balance_service.py
@@ -65,7 +65,7 @@ class CheckWalletBalanceService:
                 kwargs["commitment"] = Confirmed
             clean_address = address.strip()
             resp = self._sol.get_balance(Pubkey.from_string(clean_address), **kwargs)
-            lamports = resp.get("result", {}).get("value")
+            lamports = resp.value
             if lamports is not None:
                 return lamports / LAMPORTS_PER_SOL
         except Exception as exc:

--- a/wallets/wallet_core.py
+++ b/wallets/wallet_core.py
@@ -88,8 +88,10 @@ class WalletCore:
             log.debug("fetch_balance skipped; solana client unavailable", source="WalletCore")
             return None
         try:
-            resp = self.client.get_balance(Pubkey.from_string(wallet.public_address.strip()), commitment=Confirmed)
-            lamports = resp.get("result", {}).get("value")
+            resp = self.client.get_balance(
+                Pubkey.from_string(wallet.public_address.strip()), commitment=Confirmed
+            )
+            lamports = resp.value
             if lamports is not None:
                 return lamports / LAMPORTS_PER_SOL
         except Exception as e:


### PR DESCRIPTION
## Summary
- handle GetBalanceResp objects correctly when pulling balances
- fix wallet balance services to read lamports from `.value`
- update WalletCore balance fetch helper
- adjust tests for new Solana client responses

## Testing
- `pytest -q`