### PR TITLE
Store exported alert thresholds in config dir

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,10 +169,10 @@ a single command.
 ## Exporting Alert Thresholds
 
 Use the **Export** button on the Alert Thresholds page (or the
-`/system/alert_thresholds/export` API endpoint) to download a JSON snapshot of
-the threshold limits currently stored in the database. These exported values are
-the limits the system uses when evaluating alerts—they do **not** represent the
-current alerts themselves.
+`/system/alert_thresholds/export` API endpoint) to save a JSON snapshot of the
+current threshold limits to the `/config/alert_thresholds.json` file on the
+server. These exported values are the limits the system uses when evaluating
+alerts—they do **not** represent the current alerts themselves.
 
 ## Running `sonic_app.py`
 

--- a/data/dl_thresholds.py
+++ b/data/dl_thresholds.py
@@ -3,13 +3,14 @@ import sys
 import os
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 from core.core_imports import log
+from core.constants import CONFIG_DIR
 from datetime import datetime, timezone
 from data.models import AlertThreshold
 from uuid import uuid4
 from datetime import datetime
 import json
 
-ALERT_THRESHOLDS_JSON_PATH = "alert_thresholds.json"
+ALERT_THRESHOLDS_JSON_PATH = str(CONFIG_DIR / "alert_thresholds.json")
 
 class DLThresholdManager:
     def __init__(self, db):

--- a/static/js/alert_thresholds.js
+++ b/static/js/alert_thresholds.js
@@ -50,15 +50,15 @@ window.addEventListener('DOMContentLoaded', () => {
     try {
       const resp = await fetch('/system/alert_thresholds/export');
       const data = await resp.json();
-      const blob = new Blob([JSON.stringify(data, null, 2)], { type: 'application/json' });
-      const url = URL.createObjectURL(blob);
-      const a = document.createElement('a');
-      a.href = url;
-      a.download = 'alert_thresholds.json';
-      a.click();
-      URL.revokeObjectURL(url);
-      if (typeof showToast === 'function') {
-        showToast('✅ Exported alert_thresholds.json');
+      if (resp.ok && Array.isArray(data)) {
+        if (typeof showToast === 'function') {
+          showToast('✅ Exported alert_thresholds.json');
+        }
+      } else {
+        const msg = data.error || resp.statusText;
+        if (typeof showToast === 'function') {
+          showToast(`❌ Failed to export thresholds: ${msg}`, true);
+        }
       }
     } catch (err) {
       if (typeof showToast === 'function') {


### PR DESCRIPTION
## Summary
- export alert threshold data to `config/alert_thresholds.json`
- avoid triggering a browser download when exporting via the UI
- update documentation for new export behaviour

## Testing
- `pytest -q`