### PR TITLE
Update Phantom wallet defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -285,7 +285,7 @@ To load Phantom, specify the extension path and a profile directory when launchi
 ```python
 from playwright.sync_api import sync_playwright
 
-phantom_path = "/path/to/phantom"
+phantom_path = "wallets/phantom_wallet"  # override this path if Phantom lives elsewhere
 profile_dir = "/tmp/playwright/phantom-profile"
 
 with sync_playwright() as pw:

--- a/deposit_collateral.py
+++ b/deposit_collateral.py
@@ -1,7 +1,9 @@
 from auto_core import AutoCore
+from pathlib import Path
 
 if __name__ == "__main__":
-    PHANTOM_PATH = "/absolute/path/to/phantom/extension"
+    # Default Phantom extension path bundled with this repo. Override if needed.
+    PHANTOM_PATH = str(Path(__file__).resolve().parent / "wallets" / "phantom_wallet")
     PROFILE_DIR = "/absolute/path/to/persistent/profile"
 
     core = AutoCore(

--- a/withdraw_collateral.py
+++ b/withdraw_collateral.py
@@ -1,7 +1,9 @@
 from auto_core import AutoCore
+from pathlib import Path
 
 if __name__ == "__main__":
-    PHANTOM_PATH = "/absolute/path/to/phantom/extension"
+    # Default Phantom extension path bundled with this repo. Override if needed.
+    PHANTOM_PATH = str(Path(__file__).resolve().parent / "wallets" / "phantom_wallet")
     PROFILE_DIR = "/absolute/path/to/persistent/profile"
 
     core = AutoCore(


### PR DESCRIPTION
## Summary
- configure `deposit_collateral.py` and `withdraw_collateral.py` to use the repo's bundled Phantom wallet by default
- clarify in README how to override the default Phantom extension path

## Testing
- `pytest -q`