### PR TITLE
Make Phantom console app path configurable

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -18,5 +18,5 @@ ALERT_SMS_NUMBER=+1234567890
 JUPITER_API_BASE=https://perps-api.jup.ag
 # OpenAI API key for ChatGPT integration
 OPENAI_API_KEY=your_openai_key_here
-# Path to the unpacked Phantom extension for Playwright
+# Path to the unpacked Phantom extension for Playwright (used by `phantom_console_app`)
 PHANTOM_PATH=wallets/phantom_wallet

--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ TWILIO_TO_PHONE=+1234567890
 TWILIO_FLOW_SID=your_flow_sid_here
 JUPITER_API_BASE=https://perps-api.jup.ag
 OPENAI_API_KEY=your_openai_key_here
-# Location of the Phantom browser extension
+# Location of the Phantom browser extension (used by `phantom_console_app`)
 PHANTOM_PATH=wallets/phantom_wallet
 ```
 

--- a/jupiter_integration/console_apps/phantom_console_app.py
+++ b/jupiter_integration/console_apps/phantom_console_app.py
@@ -1,6 +1,7 @@
 """Interactive console application for Phantom wallet testing."""
 
 import os
+from pathlib import Path
 
 try:  # Optional dependency for loading environment variables
     from dotenv import load_dotenv
@@ -17,7 +18,10 @@ def main() -> None:
     """Run the Phantom wallet demo console."""
 
     # Set paths and URL (update these as needed)
-    EXTENSION_PATH = r"C:\v0.7\sonic_labs\phantom_wallet"
+    EXTENSION_PATH = os.getenv(
+        "PHANTOM_PATH",
+        str(Path(__file__).resolve().parents[2] / "wallets" / "phantom_wallet"),
+    )
     DAPP_URL = "https://jup.ag/perps-legacy/short/SOL-SOL"
     phantom_password = os.environ.get("PHANTOM_PASSWORD")
 


### PR DESCRIPTION
## Summary
- allow `phantom_console_app` to read `PHANTOM_PATH` env var
- document `PHANTOM_PATH` usage in README and `.env.example`

## Testing
- `pytest -q`