### PR TITLE
Remove Sonic Labs references from docs

### DIFF
--- a/FULL_SPEC.md
+++ b/FULL_SPEC.md
@@ -30,7 +30,7 @@ The [Hedge Core module](hedge_core/hedge_core_module_spec.md) links long and sho
 The [Monitor module](monitor/monitor_module_spec.md) drives periodic tasks and health checks. It registers individual monitors and exposes CLI and API entrypoints for running them.
 
 ### Wallets
-The [Wallet Core specification](wallets/wallet_core_spec.md) outlines wallet operations and blockchain helpers. The [Jupiter API spec](wallets/jupiter_api_spec.md) from **sonic_labs** describes how wallets interact with Jupiter Perps for managing collateral.
+The [Wallet Core specification](wallets/wallet_core_spec.md) outlines wallet operations and blockchain helpers. The [Jupiter API spec](wallets/jupiter_api_spec.md) describes how wallets interact with Jupiter Perps for managing collateral.
 
 ### Auto Core
 The [Auto Core module](auto_core/auto_core_module_spec.md) automates collateral actions in the Jupiter UI using Playwright and Phantom.

--- a/SPECIFICATIONS.md
+++ b/SPECIFICATIONS.md
@@ -31,7 +31,7 @@ The [HedgeCalcServices specification](hedge_core/hedge_calc_services_spec.md) de
 The [Monitor module](monitor/monitor_module_spec.md) drives periodic tasks and health checks. It registers individual monitors and exposes CLI and API entrypoints for running them.
 
 ### Wallets
-The [Wallet Core specification](wallets/wallet_core_spec.md) outlines wallet operations and blockchain helpers. The [Jupiter API spec](wallets/jupiter_api_spec.md) from **sonic_labs** describes how wallets interact with Jupiter Perps for managing collateral.
+The [Wallet Core specification](wallets/wallet_core_spec.md) outlines wallet operations and blockchain helpers. The [Jupiter API spec](wallets/jupiter_api_spec.md) describes how wallets interact with Jupiter Perps for managing collateral.
 
 ### GPT Input Format
 The [GPT Input specification](gpt_input_spec.md) details the JSON bundle used to send portfolio and alert context to GPT for analysis.


### PR DESCRIPTION
## Summary
- update docs to drop the `sonic_labs` mention in Wallet module sections

## Testing
- `pytest -q`