### PR TITLE
Improve Solana import logging

### DIFF
--- a/wallets/blockchain_balance_service.py
+++ b/wallets/blockchain_balance_service.py
@@ -9,6 +9,8 @@ from __future__ import annotations
 
 from typing import Optional
 
+from core.logging import log
+
 try:
     from web3 import Web3
 except Exception:  # pragma: no cover - optional dependency
@@ -18,14 +20,11 @@ try:
     from solana.rpc.api import Client
     from solana.rpc.commitment import Confirmed
     from solders.pubkey import Pubkey
-except Exception as e:  # pragma: no cover - optional dependency
-    import sys
-    print("❌ Failed to import solana/solders:", e, file=sys.stderr)
+except ImportError as e:  # pragma: no cover - optional dependency
+    log.warning("Failed to import solana/solders: %s", e)
     Client = None  # type: ignore
     Confirmed = None  # type: ignore
     Pubkey = object  # type: ignore
-
-from core.logging import log
 
 LAMPORTS_PER_SOL = 1_000_000_000
 

--- a/wallets/check_wallet_balance_service.py
+++ b/wallets/check_wallet_balance_service.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from typing import Optional
 
+from core.logging import log
+
 try:
     from web3 import Web3
 except Exception:  # pragma: no cover - optional dependency
@@ -13,14 +15,11 @@ try:
     from solana.rpc.api import Client
     from solana.rpc.commitment import Confirmed
     from solders.pubkey import Pubkey
-except Exception as e:  # pragma: no cover - optional dependency
-    import sys
-    print("❌ Failed to import solana/solders:", e, file=sys.stderr)
+except ImportError as e:  # pragma: no cover - optional dependency
+    log.warning("Failed to import solana/solders: %s", e)
     Client = None  # type: ignore
     Confirmed = None  # type: ignore
     Pubkey = object  # type: ignore
-
-from core.logging import log
 
 LAMPORTS_PER_SOL = 1_000_000_000
 

--- a/wallets/wallet_core.py
+++ b/wallets/wallet_core.py
@@ -15,6 +15,8 @@ from __future__ import annotations
 
 from typing import List, Optional
 
+from core.logging import log
+
 try:
     from solana.rpc.api import Client
     from solana.transaction import Transaction
@@ -22,9 +24,8 @@ try:
     from solders.pubkey import Pubkey
     from solana.rpc.commitment import Confirmed
     from solana.rpc.types import TxOpts
-except Exception as e:  # pragma: no cover - optional dependency
-    import sys
-    print("❌ Failed to import solana/solders:", e, file=sys.stderr)
+except ImportError as e:  # pragma: no cover - optional dependency
+    log.warning("Failed to import solana/solders: %s", e)
     Client = None
     Transaction = object
     Keypair = object
@@ -37,7 +38,6 @@ from wallets.jupiter_service import JupiterService
 
 from wallets.wallet_service import WalletService
 from wallets.wallet import Wallet
-from core.logging import log
 
 LAMPORTS_PER_SOL = 1_000_000_000
 


### PR DESCRIPTION
## Summary
- log warnings when solana modules are unavailable
- limit Solana import exceptions to `ImportError`

## Testing
- `pytest -q`