### PR TITLE
Fix Twilio SMS sender test with dummy client

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,7 +12,6 @@ TWILIO_AUTH_TOKEN=your_auth_token_here
 TWILIO_FLOW_SID=your_flow_sid_here
 TWILIO_FROM_PHONE=+1987654321
 TWILIO_TO_PHONE=+1234567890
-TWILIO_FROM_NUMBER=+1987654321
 ALERT_SMS_NUMBER=+1234567890
 # Optional Jupiter endpoint override
 JUPITER_API_BASE=https://perps-api.jup.ag

--- a/notifications/twilio_sms_sender.py
+++ b/notifications/twilio_sms_sender.py
@@ -12,10 +12,10 @@ except Exception as e:  # pragma: no cover - import may fail
 class TwilioSMSSender:
     """Simple wrapper around the Twilio REST client for SMS."""
 
-    def __init__(self, account_sid=None, auth_token=None, from_number=None):
+    def __init__(self, account_sid=None, auth_token=None, from_phone=None):
         self.account_sid = account_sid or os.getenv("TWILIO_ACCOUNT_SID")
         self.auth_token = auth_token or os.getenv("TWILIO_AUTH_TOKEN")
-        self.from_number = from_number or os.getenv("TWILIO_FROM_NUMBER")
+        self.from_phone = from_phone or os.getenv("TWILIO_FROM_PHONE")
         if Client:
             self.client = Client(self.account_sid, self.auth_token)
         else:  # pragma: no cover - if optional dependency missing
@@ -27,11 +27,11 @@ class TwilioSMSSender:
             log.error("Twilio Client not initialized", source="TwilioSMSSender")
             return False
         try:
-            if not all([self.account_sid, self.auth_token, self.from_number, to_number]):
+            if not all([self.account_sid, self.auth_token, self.from_phone, to_number]):
                 log.error("Missing Twilio SMS configuration", source="TwilioSMSSender")
                 return False
 
-            msg = self.client.messages.create(body=message, from_=self.from_number, to=to_number)
+            msg = self.client.messages.create(body=message, from_=self.from_phone, to=to_number)
             log.info(
                 "✅ SMS sent",
                 source="TwilioSMSSender",

--- a/tests/test_twilio_sms_sender.py
+++ b/tests/test_twilio_sms_sender.py
@@ -1,10 +1,28 @@
 from notifications.twilio_sms_sender import TwilioSMSSender
 
 
+class DummyClient:
+    def __init__(self, *args, **kwargs):
+        self.called = False
+
+        class Messages:
+            def __init__(self, outer):
+                self.outer = outer
+
+            def create(self, body=None, from_=None, to=None):
+                self.outer.called = True
+                return type("Msg", (), {"sid": "SM123"})()
+
+        self.messages = Messages(self)
+
+
 def test_twilio_sms_sender(monkeypatch):
     monkeypatch.setenv("TWILIO_ACCOUNT_SID", "sid")
     monkeypatch.setenv("TWILIO_AUTH_TOKEN", "token")
-    monkeypatch.setenv("TWILIO_FROM_NUMBER", "+10000000000")
+    monkeypatch.setenv("TWILIO_FROM_PHONE", "+10000000000")
+    monkeypatch.setattr("notifications.twilio_sms_sender.Client", DummyClient)
 
     sender = TwilioSMSSender()
     assert sender.send_sms("+15555555555", "test") is True
+    assert isinstance(sender.client, DummyClient)
+    assert sender.client.called is True


### PR DESCRIPTION
## Summary
- update `TwilioSMSSender` to use `TWILIO_FROM_PHONE`
- test Twilio SMS sending with a dummy Twilio client
- remove obsolete variable from `.env.example`

## Testing
- `pytest tests/test_twilio_sms_sender.py::test_twilio_sms_sender -q`
- `pytest -q`