### PR TITLE
Fix Twilio from phone env fallback

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,7 +12,6 @@ TWILIO_AUTH_TOKEN=your_auth_token_here
 TWILIO_FLOW_SID=your_flow_sid_here
 TWILIO_FROM_PHONE=+1987654321
 TWILIO_TO_PHONE=+1234567890
-TWILIO_FROM_NUMBER=+1987654321
 ALERT_SMS_NUMBER=+1234567890
 # Optional Jupiter endpoint override
 JUPITER_API_BASE=https://perps-api.jup.ag

--- a/notifications/twilio_sms_sender.py
+++ b/notifications/twilio_sms_sender.py
@@ -15,7 +15,11 @@ class TwilioSMSSender:
     def __init__(self, account_sid=None, auth_token=None, from_number=None):
         self.account_sid = account_sid or os.getenv("TWILIO_ACCOUNT_SID")
         self.auth_token = auth_token or os.getenv("TWILIO_AUTH_TOKEN")
-        self.from_number = from_number or os.getenv("TWILIO_FROM_NUMBER")
+        self.from_number = (
+            from_number
+            or os.getenv("TWILIO_FROM_PHONE")
+            or os.getenv("TWILIO_FROM_NUMBER")
+        )
         if Client:
             self.client = Client(self.account_sid, self.auth_token)
         else:  # pragma: no cover - if optional dependency missing

--- a/tests/test_twilio_sms_sender.py
+++ b/tests/test_twilio_sms_sender.py
@@ -4,7 +4,18 @@ from notifications.twilio_sms_sender import TwilioSMSSender
 def test_twilio_sms_sender(monkeypatch):
     monkeypatch.setenv("TWILIO_ACCOUNT_SID", "sid")
     monkeypatch.setenv("TWILIO_AUTH_TOKEN", "token")
-    monkeypatch.setenv("TWILIO_FROM_NUMBER", "+10000000000")
+    monkeypatch.setenv("TWILIO_FROM_PHONE", "+10000000000")
 
     sender = TwilioSMSSender()
     assert sender.send_sms("+15555555555", "test") is True
+
+
+def test_twilio_sms_sender_number_fallback(monkeypatch):
+    """Legacy TWILIO_FROM_NUMBER env var should still work."""
+    monkeypatch.setenv("TWILIO_ACCOUNT_SID", "sid")
+    monkeypatch.setenv("TWILIO_AUTH_TOKEN", "token")
+    monkeypatch.delenv("TWILIO_FROM_PHONE", raising=False)
+    monkeypatch.setenv("TWILIO_FROM_NUMBER", "+12223334444")
+
+    sender = TwilioSMSSender()
+    assert sender.from_number == "+12223334444"


### PR DESCRIPTION
## Summary
- look for `TWILIO_FROM_PHONE` when initializing `TwilioSMSSender`
- remove obsolete `TWILIO_FROM_NUMBER` from `.env.example`
- update SMS sender tests for new env var and check legacy fallback

## Testing
- `pytest -q`