### PR TITLE
Fix blueprint template lookups

### DIFF
--- a/app/alerts_bp.py
+++ b/app/alerts_bp.py
@@ -18,6 +18,7 @@ from flask import (
     redirect,
     url_for,
 )
+from jinja2 import ChoiceLoader, FileSystemLoader
 from config.config_loader import update_config as merge_config
 from utils.alert_helpers import calculate_threshold_progress
 
@@ -35,6 +36,14 @@ alerts_bp = Blueprint(
     static_folder=ALERT_MONITOR_DIR,
     static_url_path='/alerts/static'
 )
+
+# Enable template resolution from the main project's template directory as well
+# so tests creating a minimal Flask app can still locate shared templates.
+ROOT_TEMPLATES = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', 'templates'))
+alerts_bp.jinja_loader = ChoiceLoader([
+    FileSystemLoader(ALERT_MONITOR_DIR),
+    FileSystemLoader(ROOT_TEMPLATES),
+])
 
 
 

--- a/app/dashboard_bp.py
+++ b/app/dashboard_bp.py
@@ -3,6 +3,7 @@ import os
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 import asyncio
 from flask import Blueprint, render_template, jsonify, request, current_app
+from jinja2 import ChoiceLoader, FileSystemLoader
 from typing import Optional
 from data.models import AlertThreshold
 from data.data_locker import DataLocker
@@ -27,6 +28,15 @@ dashboard_bp = Blueprint(
     static_folder='dashboard',
     static_url_path='/dashboard_static'
 )
+
+# Ensure templates in the project root are also discovered when this blueprint
+# is used in isolated test apps where the Flask application's template folder
+# may not point to the repository root.
+ROOT_TEMPLATES = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', 'templates'))
+dashboard_bp.jinja_loader = ChoiceLoader([
+    FileSystemLoader(os.path.join(os.path.dirname(__file__), 'dashboard')),
+    FileSystemLoader(ROOT_TEMPLATES),
+])
 
 @dashboard_bp.route("/new_dashboard")
 def new_dashboard():

--- a/app/system_bp.py
+++ b/app/system_bp.py
@@ -15,6 +15,7 @@ from flask import (
     jsonify,
     current_app,
 )
+from jinja2 import ChoiceLoader, FileSystemLoader
 from werkzeug.utils import secure_filename
 
 # from config.alert_thresholds_json import legacy_alert_thresholds  # Simulating legacy load
@@ -30,6 +31,13 @@ UPLOAD_FOLDER = os.path.join("static", "uploads", "wallets")
 os.makedirs(UPLOAD_FOLDER, exist_ok=True)
 
 system_bp = Blueprint("system", __name__, url_prefix="/system")
+
+# Allow this blueprint to find templates in the project's main templates
+# directory when used within standalone test applications.
+ROOT_TEMPLATES = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', 'templates'))
+system_bp.jinja_loader = ChoiceLoader([
+    FileSystemLoader(ROOT_TEMPLATES),
+])
 
 
 def get_core():


### PR DESCRIPTION
## Summary
- ensure dashboard, alerts, and system blueprints can load shared templates

## Testing
- `pytest`