### PR TITLE
Fix Twilio heartbeat naming

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ PHANTOM_PATH=wallets/phantom_wallet
 ## Twilio Monitor
 
 The `twilio_monitor` runs as part of the background monitor suite. It uses
-`CheckTwilioHeartbeartService` in dry‑run mode to verify that credentials are
+`CheckTwilioHeartbeatService` in dry‑run mode to verify that credentials are
 valid without placing an actual call.
 
 ## Hedge Calculator

--- a/app/system_bp.py
+++ b/app/system_bp.py
@@ -58,10 +58,10 @@ def test_xcom():
         elif mode == "email":
             xcom.send_notification("LOW", "Test Email", msg)
         elif mode == "voice":
-            from xcom.check_twilio_heartbeart_service import CheckTwilioHeartbeartService
+            from xcom.check_twilio_heartbeat_service import CheckTwilioHeartbeatService
 
             api_cfg = xcom.config_service.get_provider("api") or {}
-            CheckTwilioHeartbeartService(api_cfg).check(dry_run=False)
+            CheckTwilioHeartbeatService(api_cfg).check(dry_run=False)
         elif mode == "system":
             SoundService().play()
 

--- a/launch_pad.py
+++ b/launch_pad.py
@@ -193,9 +193,9 @@ def check_api_status():
 
     # --- Twilio ---
     try:
-        from xcom.check_twilio_heartbeart_service import CheckTwilioHeartbeartService
+        from xcom.check_twilio_heartbeat_service import CheckTwilioHeartbeatService
 
-        result = CheckTwilioHeartbeartService({}).check(dry_run=True)
+        result = CheckTwilioHeartbeatService({}).check(dry_run=True)
         if result.get("success"):
             console.print("[green]✅ Twilio credentials valid.[/green]")
         else:

--- a/monitor/operations_monitor.py
+++ b/monitor/operations_monitor.py
@@ -185,9 +185,9 @@ class OperationsMonitor(BaseMonitor):
         api_success = False
         api_error = None
         try:
-            from xcom.check_twilio_heartbeart_service import CheckTwilioHeartbeartService
+            from xcom.check_twilio_heartbeat_service import CheckTwilioHeartbeatService
 
-            result = CheckTwilioHeartbeartService({}).check(dry_run=True)
+            result = CheckTwilioHeartbeatService({}).check(dry_run=True)
             api_success = bool(result.get("success"))
             if api_success:
                 log.success("Twilio credentials valid", source=self.name)

--- a/monitor/twilio_monitor.py
+++ b/monitor/twilio_monitor.py
@@ -5,7 +5,7 @@ sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')
 from monitor.base_monitor import BaseMonitor
 from data.data_locker import DataLocker
 from xcom.xcom_config_service import XComConfigService
-from xcom.check_twilio_heartbeart_service import CheckTwilioHeartbeartService
+from xcom.check_twilio_heartbeat_service import CheckTwilioHeartbeatService
 from core.core_imports import DB_PATH
 
 
@@ -19,7 +19,7 @@ class TwilioMonitor(BaseMonitor):
 
     def _do_work(self):
         cfg = self.config_service.get_provider("api") or {}
-        service = CheckTwilioHeartbeartService(cfg)
+        service = CheckTwilioHeartbeatService(cfg)
         result = service.check(dry_run=True)
         return result
 

--- a/system/system_core.py
+++ b/system/system_core.py
@@ -142,9 +142,9 @@ class SystemCore:
     def check_twilio_api(self) -> str:
         """Return 'ok' if Twilio credentials are valid, otherwise error text."""
         try:
-            from xcom.check_twilio_heartbeart_service import CheckTwilioHeartbeartService
+            from xcom.check_twilio_heartbeat_service import CheckTwilioHeartbeatService
 
-            result = CheckTwilioHeartbeartService({}).check(dry_run=True)
+            result = CheckTwilioHeartbeatService({}).check(dry_run=True)
             if result.get("success"):
                 return "ok"
             return result.get("error", "unknown error")

--- a/tests/test_operations_monitor.py
+++ b/tests/test_operations_monitor.py
@@ -110,7 +110,7 @@ def test_check_api_status_logs_to_xcom(monkeypatch):
 
     # Stub Twilio heartbeat
     import importlib
-    cts = importlib.import_module("xcom.check_twilio_heartbeart_service")
+    cts = importlib.import_module("xcom.check_twilio_heartbeat_service")
 
     class DummyService:
         def __init__(self, *a, **k):
@@ -119,7 +119,7 @@ def test_check_api_status_logs_to_xcom(monkeypatch):
         def check(self, dry_run=True):
             return {"success": True}
 
-    monkeypatch.setattr(cts, "CheckTwilioHeartbeartService", DummyService)
+    monkeypatch.setattr(cts, "CheckTwilioHeartbeatService", DummyService)
 
     monkeypatch.setenv("OPENAI_API_KEY", "test")
 

--- a/tests/test_system_api_status.py
+++ b/tests/test_system_api_status.py
@@ -62,7 +62,7 @@ def test_xcom_api_status_ok(monkeypatch):
 
     monkeypatch.setitem(sys.modules, "openai", types.SimpleNamespace(OpenAI=DummyClient))
 
-    cts = importlib.import_module("xcom.check_twilio_heartbeart_service")
+    cts = importlib.import_module("xcom.check_twilio_heartbeat_service")
 
     class DummyService:
         def __init__(self, *a, **k):
@@ -71,7 +71,7 @@ def test_xcom_api_status_ok(monkeypatch):
         def check(self, dry_run=True):
             return {"success": True}
 
-    monkeypatch.setattr(cts, "CheckTwilioHeartbeartService", DummyService)
+    monkeypatch.setattr(cts, "CheckTwilioHeartbeatService", DummyService)
     monkeypatch.setenv("OPENAI_API_KEY", "test")
 
     class DummyResp:

--- a/tests/test_system_core_connectivity.py
+++ b/tests/test_system_core_connectivity.py
@@ -25,8 +25,11 @@ def test_check_twilio_api_success(monkeypatch):
         def check(self, dry_run=True):
             return {"success": True}
 
-    monkeypatch.setitem(sys.modules, "xcom.check_twilio_heartbeart_service",
-                        types.SimpleNamespace(CheckTwilioHeartbeartService=DummyService))
+    monkeypatch.setitem(
+        sys.modules,
+        "xcom.check_twilio_heartbeat_service",
+        types.SimpleNamespace(CheckTwilioHeartbeatService=DummyService),
+    )
     sc = load_core(monkeypatch)
     core = make_core(sc)
     assert core.check_twilio_api() == "ok"
@@ -39,8 +42,11 @@ def test_check_twilio_api_failure(monkeypatch):
         def check(self, dry_run=True):
             return {"success": False, "error": "fail"}
 
-    monkeypatch.setitem(sys.modules, "xcom.check_twilio_heartbeart_service",
-                        types.SimpleNamespace(CheckTwilioHeartbeartService=DummyService))
+    monkeypatch.setitem(
+        sys.modules,
+        "xcom.check_twilio_heartbeat_service",
+        types.SimpleNamespace(CheckTwilioHeartbeatService=DummyService),
+    )
     sc = load_core(monkeypatch)
     core = make_core(sc)
     assert core.check_twilio_api() == "fail"

--- a/utils/startup_service.py
+++ b/utils/startup_service.py
@@ -21,7 +21,7 @@ from core.constants import (
 from utils.schema_validation_service import SchemaValidationService
 from data.data_locker import DataLocker
 from monitor.operations_monitor import OperationsMonitor
-from xcom.check_twilio_heartbeart_service import CheckTwilioHeartbeartService
+from xcom.check_twilio_heartbeat_service import CheckTwilioHeartbeatService
 from utils.path_audit import run_audit
 from xcom.sound_service import SoundService
 from scripts.verify_all_tables_exist import verify_all_tables_exist
@@ -270,7 +270,7 @@ class StartUpService:
     @staticmethod
     def run_twilio_heartbeat():
         try:
-            result = CheckTwilioHeartbeartService({}).check(dry_run=True)
+            result = CheckTwilioHeartbeatService({}).check(dry_run=True)
             if not result.get("success"):
                 log.error(
                     f"Twilio heartbeat check failed: {result.get('error')}",

--- a/xcom/check_twilio_heartbeat_service.py
+++ b/xcom/check_twilio_heartbeat_service.py
@@ -8,7 +8,7 @@ from core.logging import log
 from .voice_service import VoiceService
 
 
-class CheckTwilioHeartbeartService:
+class CheckTwilioHeartbeatService:
     """Verify Twilio credentials and optionally place a test voice call."""
 
     def __init__(self, config: Dict):

--- a/xcom/xcom_core_spec.md
+++ b/xcom/xcom_core_spec.md
@@ -15,7 +15,7 @@ xcom/
 ├── sms_service.py                 # 💬 SMS via carrier gateway
 ├── voice_service.py               # 📞 Twilio voice calls
 ├── sound_service.py               # 🔊 Local audio playback
-└── check_twilio_heartbeart_service.py # ❤️ Twilio credential check
+└── check_twilio_heartbeat_service.py  # ❤️ Twilio credential check
 ```
 
 ### 🔧 `XComCore`
@@ -42,7 +42,7 @@ send_notification(level, subject, body, recipient="", initiator="system") -> dic
 - **VoiceService** – wraps Twilio's client to place a voice call that reads the
   supplied message.
 - **SoundService** – plays an MP3 file on the local system as an audible alert.
-- **CheckTwilioHeartbeartService** – validates Twilio credentials and can trigger
+- **CheckTwilioHeartbeatService** – validates Twilio credentials and can trigger
   a test call in non-dry-run mode.
 
 ### 🧰 Configuration


### PR DESCRIPTION
## Summary
- fix typo in CheckTwilioHeartbeatService class and rename file
- update imports and docs referencing the service name
- adjust tests for new class name

## Testing
- `pytest -q`
- `pytest tests/test_operations_monitor.py tests/test_system_api_status.py tests/test_system_core_connectivity.py -q`