### PR TITLE
Improve console balance error and twilio sender

### DIFF
--- a/jupiter_console.py
+++ b/jupiter_console.py
@@ -118,6 +118,11 @@ def check_balance_flow(core: WalletCore):
     if balance is not None:
         console.print(f"💰 [green]{wallet.name}[/green] has [cyan]{balance:.4f} SOL[/cyan]")
     else:
+        if core.client is None:
+            console.print(
+                "[yellow]Solana packages missing. Install them with:[/yellow]"
+            )
+            console.print("pip install solana==0.36.6 solders==0.26.0")
         console.print(f"🚫 [red]Could not fetch balance for {wallet.name}[/red]")
 
 

--- a/notifications/twilio_sms_sender.py
+++ b/notifications/twilio_sms_sender.py
@@ -15,8 +15,8 @@ class TwilioSMSSender:
     def __init__(self, account_sid=None, auth_token=None, from_phone=None):
         self.account_sid = account_sid or os.getenv("TWILIO_ACCOUNT_SID")
         self.auth_token = auth_token or os.getenv("TWILIO_AUTH_TOKEN")
-        self.from_number = (
-            from_number
+        self.from_phone = (
+            from_phone
             or os.getenv("TWILIO_FROM_PHONE")
             or os.getenv("TWILIO_FROM_NUMBER")
         )


### PR DESCRIPTION
## Summary
- show better message when solana libraries are missing in `jupiter_console`
- fix NameError in `TwilioSMSSender`

## Testing
- `pytest tests/test_jupiter_service.py -q`
- `pytest tests/test_twilio_sms_sender.py -q`
- `pytest -q`