### PR TITLE
Fix failing alerts API tests

### DIFF
--- a/app/alerts_bp.py
+++ b/app/alerts_bp.py
@@ -5,6 +5,7 @@ import asyncio
 import os
 from types import SimpleNamespace
 from flask import current_app
+from datetime import datetime
 from alert_core.alert_utils import resolve_wallet_metadata
 from dashboard.dashboard_service import WALLET_IMAGE_MAP, DEFAULT_WALLET_IMAGE
 
@@ -105,6 +106,7 @@ def create_all_alerts():
         sample_alerts = [
             {
                 "id": "alert-sample-1",
+                "created_at": datetime.now().isoformat(),
                 "alert_type": "PriceThreshold",
                 "alert_class": "Market",
                 "asset_type": "BTC",


### PR DESCRIPTION
## Summary
- ensure sample alert has `created_at` timestamp when creating via the alerts API

## Testing
- `pytest -k alerts_api -vv` *(tests skipped: Flask not installed)*