### PR TITLE
Clean up import path tweaks in data modules

### DIFF
--- a/data/data_locker.py
+++ b/data/data_locker.py
@@ -12,11 +12,9 @@ Dependencies:
     - DLAlertManager, DLPriceManager, etc.
 """
 
-import sys
 import os
 import json
 import sqlite3
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 from data.database import DatabaseManager
 from data.dl_alerts import DLAlertManager
 from data.dl_prices import DLPriceManager

--- a/data/dl_alerts.py
+++ b/data/dl_alerts.py
@@ -1,6 +1,3 @@
-import sys
-import os
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 from core.core_imports import log
 # dl_alerts.py
 """

--- a/data/dl_hedges.py
+++ b/data/dl_hedges.py
@@ -9,10 +9,6 @@ Description:
     :class:`~positions.hedge_manager.HedgeManager`.
 """
 
-import sys
-import os
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
-
 from positions.hedge_manager import HedgeManager
 from core.core_imports import log
 

--- a/data/dl_monitor_ledger.py
+++ b/data/dl_monitor_ledger.py
@@ -1,7 +1,3 @@
-import sys
-import os
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
-
 import sqlite3
 import json
 import uuid

--- a/data/dl_positions.py
+++ b/data/dl_positions.py
@@ -10,9 +10,7 @@ Dependencies:
     - DatabaseManager from database.py
     - ConsoleLogger from console_logger.py
 """
-import sys
 import os
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 from uuid import uuid4
 from datetime import datetime
 from core.core_imports import log

--- a/data/dl_system_data.py
+++ b/data/dl_system_data.py
@@ -7,14 +7,11 @@ Description:
     total balances, and strategy performance metadata.
 """
 
-import sys
-import os
 import json
 from datetime import datetime
 from core.core_imports import log
 from data.models import SystemVariables
 
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 
 
 class DLSystemDataManager:

--- a/data/dl_thresholds.py
+++ b/data/dl_thresholds.py
@@ -1,7 +1,5 @@
 # dl_thresholds.py
-import sys
 import os
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 from core.core_imports import log
 from core.constants import CONFIG_DIR
 from datetime import datetime, timezone

--- a/data/seed_database.py
+++ b/data/seed_database.py
@@ -7,12 +7,10 @@ Run from the project root:
     python -m data.seed_database
 """
 
-import os
-import sys
+
 
 # Allow running this file directly.
-if __name__ == "__main__" and __package__ is None:
-    sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
 
 from core.core_imports import configure_console_log
 from core.constants import DB_PATH

--- a/data/test_travel_percent_lifecycle.py
+++ b/data/test_travel_percent_lifecycle.py
@@ -1,8 +1,4 @@
 __test__ = False
-import sys
-import os
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
-
 
 import asyncio
 from datetime import datetime

--- a/data/threshold_seeder.py
+++ b/data/threshold_seeder.py
@@ -21,15 +21,9 @@ from uuid import uuid4
 from data.models import AlertThreshold
 from data.dl_thresholds import DLThresholdManager
 
-import os
 import sys
 
 from core.constants import DB_PATH as CONST_DB_PATH
-
-
-# Allow running this file directly by ensuring the project root is on sys.path.
-if __name__ == "__main__" and __package__ is None:
-    sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 
 DB_PATH = str(CONST_DB_PATH)


### PR DESCRIPTION
## Summary
- drop `sys.path.insert` calls from data package
- remove unused `sys`/`os` imports
- keep modules importable without runtime path hacking

## Testing
- `pytest -q`