### PR TITLE
Handle optional data_locker in GPT blueprint

### DIFF
--- a/gpt/gpt_bp.py
+++ b/gpt/gpt_bp.py
@@ -83,7 +83,8 @@ def oracle_query():
     except KeyError:
         return jsonify({"error": "Unknown persona"}), 400
 
-    oracle = OracleCore(core.data_locker)
+    data_locker = getattr(core, "data_locker", None)
+    oracle = OracleCore(data_locker)
     oracle.client = core.client
 
     if topic not in oracle.handlers:


### PR DESCRIPTION
## Summary
- avoid attribute error if GPTCore lacks data_locker
- keep rest of oracle query logic intact

## Testing
- `pytest tests/test_gpt_bp_api.py tests/test_gpt_strategies.py -q`