### PR TITLE
Add positions context

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ with status code `0` on success and `1` on failure.
 ## GPT Oracle
 
 Run `python sonic_app.py` and navigate to `/GPT/chat` to open the oracle front end.
-The page shows four buttons—`portfolio`, `alerts`, `prices`, and `system`—that
+The page shows five buttons—`portfolio`, `positions`, `alerts`, `prices`, and `system`—that
 query the `/gpt/oracle/<topic>` API and display the reply using **OracleCore**.
 OracleCore aggregates context, applies optional strategies, and sends the prompt
 to GPT.
@@ -121,7 +121,7 @@ The API can be called directly as well:
 curl "http://localhost:5000/gpt/oracle/portfolio?strategy=none"
 ```
 
-Replace `portfolio` with any other topic to receive a short summary. Use the
+Replace `portfolio` with any other topic (like `positions`, `alerts`, `prices`, or `system`) to receive a short summary. Use the
 `strategy` query parameter to apply a named strategy (defaults to `none`).
 
 System queries now include the latest update timestamps along with recent

--- a/oracle_core/__init__.py
+++ b/oracle_core/__init__.py
@@ -8,6 +8,7 @@ from .portfolio_topic_handler import PortfolioTopicHandler
 from .alerts_topic_handler import AlertsTopicHandler
 from .prices_topic_handler import PricesTopicHandler
 from .system_topic_handler import SystemTopicHandler
+from .positions_topic_handler import PositionsTopicHandler
 
 __all__ = [
     "OracleCore",
@@ -20,4 +21,5 @@ __all__ = [
     "AlertsTopicHandler",
     "PricesTopicHandler",
     "SystemTopicHandler",
+    "PositionsTopicHandler",
 ]

--- a/oracle_core/oracle_core.py
+++ b/oracle_core/oracle_core.py
@@ -13,6 +13,7 @@ from .portfolio_topic_handler import PortfolioTopicHandler
 from .alerts_topic_handler import AlertsTopicHandler
 from .prices_topic_handler import PricesTopicHandler
 from .system_topic_handler import SystemTopicHandler
+from .positions_topic_handler import PositionsTopicHandler
 
 
 class OracleCore:
@@ -23,6 +24,7 @@ class OracleCore:
         "alerts": "You summarize alert information.",
         "prices": "You summarize price information.",
         "system": "You report system status.",
+        "positions": "You summarize position information.",
     }
 
     DEFAULT_INSTRUCTIONS = {
@@ -30,6 +32,7 @@ class OracleCore:
         "alerts": "Summarize the current alert state.",
         "prices": "Summarize the market trends.",
         "system": "Summarize the system health status.",
+        "positions": "Provide a summary of open positions.",
     }
 
     def __init__(self, data_locker):
@@ -47,6 +50,7 @@ class OracleCore:
         self.register_topic_handler("alerts", AlertsTopicHandler(data_locker))
         self.register_topic_handler("prices", PricesTopicHandler(data_locker))
         self.register_topic_handler("system", SystemTopicHandler(data_locker))
+        self.register_topic_handler("positions", PositionsTopicHandler(data_locker))
 
     # public API
     def register_topic_handler(self, name: str, handler: object):

--- a/oracle_core/oracle_core_spec.md
+++ b/oracle_core/oracle_core_spec.md
@@ -14,9 +14,10 @@ oracle_core/
 ├── strategy_manager.py      # Load strategy definitions
 ├── persona_manager.py       # Load persona definitions
 ├── alerts_topic_handler.py  # Build alerts context
-├── portfolio_topic_handler.py # Build portfolio context
-├── prices_topic_handler.py  # Build price context
-├── system_topic_handler.py  # Build system status context
+├── portfolio_topic_handler.py   # Build portfolio context
+├── positions_topic_handler.py   # Build positions context
+├── prices_topic_handler.py      # Build price context
+├── system_topic_handler.py      # Build system status context
 ├── personas/                # Default persona JSON files
 └── strategies/              # Strategy modifier JSON files
 ```
@@ -40,6 +41,7 @@ class OracleCore:
         self.register_topic_handler("alerts", AlertsTopicHandler(data_locker))
         self.register_topic_handler("prices", PricesTopicHandler(data_locker))
         self.register_topic_handler("system", SystemTopicHandler(data_locker))
+        self.register_topic_handler("positions", PositionsTopicHandler(data_locker))
 ```
 【F:oracle_core/oracle_core.py†L16-L38】
 
@@ -49,11 +51,12 @@ class OracleCore:
 `PersonaManager` loads persona JSON files that provide instructions and strategy weights. `StrategyManager` loads strategy JSON files defining modifier dictionaries. Persona weights are merged so multiple strategies can influence the final prompt.
 
 ### 🗂️ Topic Handlers
-Each handler (`PortfolioTopicHandler`, `AlertsTopicHandler`, `PricesTopicHandler`, `SystemTopicHandler`) returns a small context dictionary via `OracleDataService`.
+Each handler (`PortfolioTopicHandler`, `PositionsTopicHandler`, `AlertsTopicHandler`, `PricesTopicHandler`, `SystemTopicHandler`) returns a small context dictionary via `OracleDataService`.
 
 ### 🛰️ Data Service
 `OracleDataService` wraps `DataLocker` managers and exposes helpers:
 - `fetch_portfolio()` → latest portfolio snapshot
 - `fetch_alerts()` → recent alerts
 - `fetch_prices()` → recent prices
+- `fetch_positions()` → recent positions
 - `fetch_system()` → `{"last_update_times": ..., "death_log": [...], "system_alerts": [...]}`

--- a/oracle_core/oracle_data_service.py
+++ b/oracle_core/oracle_data_service.py
@@ -13,6 +13,10 @@ class OracleDataService:
     def fetch_prices(self):
         return self.dl.prices.get_all_prices()[:20]
 
+    def fetch_positions(self):
+        """Return recent positions for context."""
+        return self.dl.positions.get_all_positions()[:20]
+
     def fetch_death_log(self):
         return self.dl.get_death_log_entries()
 
@@ -33,6 +37,8 @@ class OracleDataService:
             return self.fetch_alerts()
         if topic == "prices":
             return self.fetch_prices()
+        if topic == "positions":
+            return self.fetch_positions()
         if topic == "system":
             return self.fetch_system()
         raise ValueError(f"Unsupported topic: {topic}")

--- a/oracle_core/positions_topic_handler.py
+++ b/oracle_core/positions_topic_handler.py
@@ -1,0 +1,17 @@
+from typing import Dict
+
+from .oracle_data_service import OracleDataService
+
+
+class PositionsTopicHandler:
+    """Provide positions context for GPT."""
+
+    output_key = "positions"
+    system_message = "You summarize position information."
+
+    def __init__(self, data_locker):
+        self.data_service = OracleDataService(data_locker)
+
+    def get_context(self) -> Dict:
+        positions = self.data_service.fetch_positions()
+        return {self.output_key: positions}

--- a/templates/positions_table.html
+++ b/templates/positions_table.html
@@ -1,6 +1,6 @@
 <link rel="stylesheet" href="{{ url_for('static', filename='css/dashboard_middle.css') }}">
 <div class="section-title">Positions
-  <span class="oracle-icon" data-topic="prices" title="Ask the Oracle">🔮</span>
+  <span class="oracle-icon" data-topic="positions" title="Ask the Oracle">🔮</span>
 </div>
 <div class="positions-table-wrapper">
   <table class="positions-table">

--- a/tests/test_gpt_strategies.py
+++ b/tests/test_gpt_strategies.py
@@ -62,11 +62,16 @@ def setup_core(monkeypatch):
         def get_last_update_times(self):
             return {}
 
+    class DummyPositions:
+        def get_all_positions(self):
+            return []
+
     class DummyLocker:
         def __init__(self, *a, **k):
             self.alerts = DummyAlerts()
             self.prices = DummyPrices()
             self.portfolio = DummyPortfolio()
+            self.positions = DummyPositions()
             self.system = DummySystem()
 
         def get_last_update_times(self):


### PR DESCRIPTION
## Summary
- add PositionsTopicHandler for GPT oracle
- register positions topic in OracleCore and update defaults
- mention positions context in docs
- support positions topic in tests
- allow dashboard oracle to query positions

## Testing
- `pytest -q`