### PR TITLE
Add template folder to system blueprint

### DIFF
--- a/app/system_bp.py
+++ b/app/system_bp.py
@@ -30,7 +30,12 @@ from positions.hedge_manager import HedgeManager
 UPLOAD_FOLDER = os.path.join("static", "uploads", "wallets")
 os.makedirs(UPLOAD_FOLDER, exist_ok=True)
 
-system_bp = Blueprint("system", __name__, url_prefix="/system")
+system_bp = Blueprint(
+    "system",
+    __name__,
+    url_prefix="/system",
+    template_folder="../templates",
+)
 
 # Allow this blueprint to find templates in the project's main templates
 # directory when used within standalone test applications.


### PR DESCRIPTION
## Summary
- set `template_folder='../templates'` when creating the system blueprint
- keep ChoiceLoader logic for root templates

## Testing
- `pytest -q`