### PR TITLE
Add template loader for sonic_labs blueprint

### DIFF
--- a/sonic_labs/sonic_labs_bp.py
+++ b/sonic_labs/sonic_labs_bp.py
@@ -2,6 +2,8 @@
 # sonic_labs_bp.py
 
 from flask import Blueprint, jsonify, current_app, request, render_template
+import os
+from jinja2 import ChoiceLoader, FileSystemLoader
 import json
 from positions.position_sync_service import PositionSyncService  # noqa: F401
 from positions.position_core_service import PositionCoreService  # noqa: F401
@@ -27,6 +29,12 @@ WALLET_IMAGE_MAP = {
 DEFAULT_WALLET_IMAGE = "unknown_wallet.jpg"
 
 sonic_labs_bp = Blueprint("sonic_labs", __name__, template_folder="templates")
+
+# Allow this blueprint to locate templates when used in isolation
+ROOT_TEMPLATES = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', 'templates'))
+sonic_labs_bp.jinja_loader = ChoiceLoader([
+    FileSystemLoader(ROOT_TEMPLATES),
+])
 
 @sonic_labs_bp.route("/hedge_calculator", methods=["GET"])
 @retry_on_locked()


### PR DESCRIPTION
## Summary
- import `os`, `ChoiceLoader`, and `FileSystemLoader`
- expose root templates path for `sonic_labs_bp`
- set blueprint jinja_loader to allow use outside the main app

## Testing
- `pytest -k hedge_calculator_page -q` *(fails: 14 skipped, 112 deselected)*