### PR TITLE
Convert alert thresholds to schema-based format

### DIFF
--- a/config/alert_thresholds.json
+++ b/config/alert_thresholds.json
@@ -1,62 +1,46 @@
-[
-  {
-    "id": "d87c8a67-6b7e-40b8-9d4d-777e12cc49fd",
-    "alert_type": "HeatIndex",
-    "alert_class": "Position",
-    "metric_key": "heatindex",
-    "condition": "ABOVE",
-    "low": 10.0,
-    "medium": 25.0,
-    "high": 45.0,
-    "enabled": 0,
-    "last_modified": "2025-05-29T01:42:12.555112+00:00",
-    "low_notify": "Email",
-    "medium_notify": "Email",
-    "high_notify": "Email"
+{
+  "alert_ranges": {
+    "liquidation_distance_ranges": {},
+    "travel_percent_liquid_ranges": {},
+    "heat_index_ranges": {
+      "low": 10.0,
+      "medium": 25.0,
+      "high": 45.0,
+      "enabled": false
+    },
+    "profit_ranges": {
+      "low": 15.0,
+      "medium": 60.0,
+      "high": 120.0,
+      "enabled": false
+    },
+    "price_alerts": {}
   },
-  {
-    "id": "1f1e80c2-89a3-44c8-887d-be1fd9d945f0",
-    "alert_type": "PriceThreshold",
-    "alert_class": "Market",
-    "metric_key": "price",
-    "condition": "ABOVE",
-    "low": 20005.0,
-    "medium": 30010.0,
-    "high": 40020.0,
-    "enabled": 1,
-    "last_modified": "2025-05-29T01:42:12.555964+00:00",
-    "low_notify": "",
-    "medium_notify": "",
-    "high_notify": ""
+  "cooldowns": {
+    "alert_cooldown_seconds": 300,
+    "call_refractory_period": 900,
+    "snooze_countdown": 300
   },
-  {
-    "id": "793f3d9d-275c-4485-a28d-389098bd60eb",
-    "alert_type": "Profit",
-    "alert_class": "Position",
-    "metric_key": "profit",
-    "condition": "ABOVE",
-    "low": 15.0,
-    "medium": 60.0,
-    "high": 120.0,
-    "enabled": 0,
-    "last_modified": "2025-05-29T01:42:12.554539+00:00",
-    "low_notify": "SMS,Email,Voice",
-    "medium_notify": "SMS,Email,Voice",
-    "high_notify": "SMS,Email,Voice"
-  },
-  {
-    "id": "eca0298b-5931-4d1d-9a24-d630ba84574f",
-    "alert_type": "TotalValue",
-    "alert_class": "Portfolio",
-    "metric_key": "total_value",
-    "condition": "ABOVE",
-    "low": 10005.0,
-    "medium": 25010.0,
-    "high": 50020.0,
-    "enabled": 0,
-    "last_modified": "2025-05-29T01:42:12.555555+00:00",
-    "low_notify": "",
-    "medium_notify": "",
-    "high_notify": "SMS"
+  "notifications": {
+    "heat_index": {
+      "low": ["Email"],
+      "medium": ["Email"],
+      "high": ["Email"]
+    },
+    "travel_percent_liquid": {
+      "low": [],
+      "medium": [],
+      "high": []
+    },
+    "profit": {
+      "low": ["SMS", "Email", "Voice"],
+      "medium": ["SMS", "Email", "Voice"],
+      "high": ["SMS", "Email", "Voice"]
+    },
+    "price_alerts": {
+      "low": [],
+      "medium": [],
+      "high": []
+    }
   }
-]
+}


### PR DESCRIPTION
## Summary
- modernize `alert_thresholds.json` to use object-based schema
- validate new config with `SchemaValidationService`

## Testing
- `pytest -q`
- `python - <<'PY'
import sys, os
sys.path.insert(0, os.getcwd())
import tests.conftest
from utils.schema_validation_service import SchemaValidationService
from core.constants import ALERT_THRESHOLDS_PATH
print('valid', SchemaValidationService.validate_schema(str(ALERT_THRESHOLDS_PATH), SchemaValidationService.ALERT_THRESHOLDS_SCHEMA, name='Alert Ranges'))
PY`