### PR TITLE
Fix Cyclone test import path

### DIFF
--- a/cyclone/tests/test_cyclone_step_clear_all_data.py
+++ b/cyclone/tests/test_cyclone_step_clear_all_data.py
@@ -1,6 +1,9 @@
 import sys
 import os
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+# Ensure the project root is on the path so data/* imports work when this
+# test is run directly rather than through ``pytest``'s configured testpaths.
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..")))
 import random
 from uuid import uuid4
 from datetime import datetime


### PR DESCRIPTION
## Summary
- fix sys.path so cyclone clear data test runs when invoked directly

## Testing
- `pytest -q`
- `pytest cyclone/tests/test_cyclone_step_clear_all_data.py -vv`