### PR TITLE
Add heat strategy defaults to positions

### DIFF
--- a/oracle_core/oracle_core.py
+++ b/oracle_core/oracle_core.py
@@ -80,6 +80,14 @@ class OracleCore:
         context = handler.get_context()
         instructions = self.DEFAULT_INSTRUCTIONS.get(topic, "Assist the user.")
 
+        if topic == "positions" and not strategy_name:
+            try:
+                default_strat = self.strategy_manager.get("heat_control")
+                context = default_strat.apply(context)
+                instructions = default_strat.instructions or instructions
+            except KeyError:  # pragma: no cover - defensive
+                pass
+
         if strategy_name:
             try:
                 strategy = self.strategy_manager.get(strategy_name)

--- a/oracle_core/oracle_core_spec.md
+++ b/oracle_core/oracle_core_spec.md
@@ -60,3 +60,6 @@ Each handler (`PortfolioTopicHandler`, `PositionsTopicHandler`, `AlertsTopicHand
 - `fetch_prices()` → recent prices
 - `fetch_positions()` → recent positions
 - `fetch_system()` → `{"last_update_times": ..., "death_log": [...], "system_alerts": [...]}`
+- Positions queries automatically apply the `heat_control` strategy if no
+  strategy is provided, injecting heat thresholds and instructions into the
+  context.

--- a/tests/test_gpt_strategies.py
+++ b/tests/test_gpt_strategies.py
@@ -105,6 +105,16 @@ def test_gptcore_ask_oracle_applies_strategy(monkeypatch):
     assert messages[-1]["content"] == "Answer briefly and focus on risk mitigation."
 
 
+def test_gptcore_positions_default_heat_strategy(monkeypatch):
+    GPTCore = setup_core(monkeypatch)
+    core = GPTCore()
+    messages = core.ask_oracle("positions")
+    ctx = json.loads(messages[1]["content"])
+    mods = ctx.get("strategy_modifiers", {})
+    assert mods.get("heat_thresholds", {}).get("warning") == 30
+    assert "Monitor the heat index" in messages[-1]["content"]
+
+
 @pytest.fixture
 def client(monkeypatch):
     flask = importlib.import_module("flask")


### PR DESCRIPTION
## Summary
- apply the `heat_control` strategy when querying OracleCore for positions
- document default heat strategy behavior
- test that positions queries include heat strategy by default

## Testing
- `pytest -q`