### PR TITLE
Include avg_heat_index in positions context

### DIFF
--- a/oracle_core/positions_topic_handler.py
+++ b/oracle_core/positions_topic_handler.py
@@ -1,5 +1,6 @@
 from typing import Dict
 
+from calc_core.calc_services import CalcServices
 from .oracle_data_service import OracleDataService
 
 
@@ -14,4 +15,8 @@ class PositionsTopicHandler:
 
     def get_context(self) -> Dict:
         positions = self.data_service.fetch_positions()
-        return {self.output_key: positions}
+        totals = CalcServices().calculate_totals(positions)
+        return {
+            self.output_key: positions,
+            "avg_heat_index": totals.get("avg_heat_index", 0.0),
+        }

--- a/tests/test_positions_topic_handler.py
+++ b/tests/test_positions_topic_handler.py
@@ -1,0 +1,39 @@
+import importlib.util
+from pathlib import Path
+
+
+def load_module():
+    base = Path(__file__).resolve().parents[1]
+    path = base / "oracle_core" / "positions_topic_handler.py"
+    spec = importlib.util.spec_from_file_location("oracle_core.positions_topic_handler", path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec and spec.loader
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_get_context_includes_avg_heat_index(monkeypatch):
+    mod = load_module()
+    handler = mod.PositionsTopicHandler(None)
+    positions = [
+        {
+            "size": 1.0,
+            "value": 100.0,
+            "collateral": 50.0,
+            "leverage": 2.0,
+            "travel_percent": 5.0,
+            "heat_index": 10.0,
+        },
+        {
+            "size": 1.0,
+            "value": 50.0,
+            "collateral": 25.0,
+            "leverage": 1.0,
+            "travel_percent": 2.5,
+            "heat_index": 20.0,
+        },
+    ]
+    monkeypatch.setattr(handler.data_service, "fetch_positions", lambda: positions)
+    context = handler.get_context()
+    assert context[handler.output_key] == positions
+    assert context["avg_heat_index"] == 15.0


### PR DESCRIPTION
## Summary
- compute totals in `PositionsTopicHandler.get_context`
- expose `avg_heat_index` in returned context
- add regression test for new behaviour

## Testing
- `pytest -q`
