### PR TITLE
Seed sample alerts on startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,6 +240,10 @@ python scripts/initialize_database.py --reset --seed-thresholds --seed-wallets
 python scripts/initialize_database.py --all
 ```
 
+If the `alerts` table is empty and `config/sample_alerts.json` is present, the
+`DataLocker` will automatically load these sample alerts on first run. This
+prevents the dashboard from showing "No alerts available" after a fresh setup.
+
 If you encounter SQLite errors such as `file is not a database`, the
 database file is likely corrupted. Rebuild it by running:
 

--- a/config/sample_alerts.json
+++ b/config/sample_alerts.json
@@ -1,0 +1,25 @@
+[
+  {
+    "id": "alert-sample-1",
+    "created_at": "2024-01-01T00:00:00",
+    "alert_type": "PriceThreshold",
+    "alert_class": "Market",
+    "asset_type": "BTC",
+    "trigger_value": 60000,
+    "condition": "ABOVE",
+    "notification_type": "SMS",
+    "level": "Normal",
+    "last_triggered": null,
+    "status": "Active",
+    "frequency": 1,
+    "counter": 0,
+    "liquidation_distance": 0.0,
+    "travel_percent": -10.0,
+    "liquidation_price": 50000,
+    "notes": "Sample BTC price alert",
+    "description": "Test alert for BTC above 60k",
+    "position_reference_id": null,
+    "evaluated_value": 59000,
+    "position_type": null
+  }
+]

--- a/tests/test_alert_core_create_all.py
+++ b/tests/test_alert_core_create_all.py
@@ -8,6 +8,7 @@ def test_create_all_alerts_runs(tmp_path, monkeypatch):
     monkeypatch.setattr(DataLocker, "_seed_modifiers_if_empty", lambda self: None)
     monkeypatch.setattr(DataLocker, "_seed_wallets_if_empty", lambda self: None)
     monkeypatch.setattr(DataLocker, "_seed_thresholds_if_empty", lambda self: None)
+    monkeypatch.setattr(DataLocker, "_seed_alerts_if_empty", lambda self: None)
 
     dl = DataLocker(str(tmp_path / "core.db"))
     core = AlertCore(dl)

--- a/tests/test_alert_creation_configurebility.py
+++ b/tests/test_alert_creation_configurebility.py
@@ -59,7 +59,9 @@ def _disabled_config():
     }
 
 
-def test_alert_creation_configurebility(tmp_path):
+def test_alert_creation_configurebility(tmp_path, monkeypatch):
+    monkeypatch.setattr(DataLocker, "_seed_alerts_if_empty", lambda self: None)
+
     db_path = tmp_path / "enabled.db"
     dl = DataLocker(str(db_path))
     _insert_position(dl)

--- a/tests/test_alert_disabled_creation.py
+++ b/tests/test_alert_disabled_creation.py
@@ -19,7 +19,9 @@ def _insert_position(dl):
     dl.positions.insert_position(pos)
 
 
-def test_position_alert_respects_disabled(tmp_path):
+def test_position_alert_respects_disabled(tmp_path, monkeypatch):
+    monkeypatch.setattr(DataLocker, "_seed_alerts_if_empty", lambda self: None)
+
     db_path = tmp_path / "alerts.db"
     dl = DataLocker(str(db_path))
     _insert_position(dl)
@@ -43,7 +45,9 @@ def test_position_alert_respects_disabled(tmp_path):
     assert types == {"TravelPercentLiquid"}
 
 
-def test_portfolio_alert_respects_disabled(tmp_path):
+def test_portfolio_alert_respects_disabled(tmp_path, monkeypatch):
+    monkeypatch.setattr(DataLocker, "_seed_alerts_if_empty", lambda self: None)
+
     db_path = tmp_path / "alerts2.db"
     dl = DataLocker(str(db_path))
 
@@ -65,7 +69,9 @@ def test_portfolio_alert_respects_disabled(tmp_path):
     assert types == {"TotalSize"}
 
 
-def test_disabled_string_values(tmp_path):
+def test_disabled_string_values(tmp_path, monkeypatch):
+    monkeypatch.setattr(DataLocker, "_seed_alerts_if_empty", lambda self: None)
+
     db_path = tmp_path / "alerts3.db"
     dl = DataLocker(str(db_path))
     _insert_position(dl)

--- a/tests/test_alerts_api.py
+++ b/tests/test_alerts_api.py
@@ -15,6 +15,7 @@ def client(tmp_path, monkeypatch):
     monkeypatch.setattr(DataLocker, "_seed_modifiers_if_empty", lambda self: None)
     monkeypatch.setattr(DataLocker, "_seed_wallets_if_empty", lambda self: None)
     monkeypatch.setattr(DataLocker, "_seed_thresholds_if_empty", lambda self: None)
+    monkeypatch.setattr(DataLocker, "_seed_alerts_if_empty", lambda self: None)
 
     dl = DataLocker(str(tmp_path / "alerts.db"))
 

--- a/tests/test_database_recovery.py
+++ b/tests/test_database_recovery.py
@@ -8,6 +8,7 @@ from data.data_locker import DataLocker
 def test_recover_malformed_db(tmp_path, monkeypatch):
     monkeypatch.setattr(DataLocker, "_seed_modifiers_if_empty", lambda self: None)
     monkeypatch.setattr(DataLocker, "_seed_wallets_if_empty", lambda self: None)
+    monkeypatch.setattr(DataLocker, "_seed_alerts_if_empty", lambda self: None)
 
     db_path = tmp_path / "test.db"
     dl = DataLocker(str(db_path))

--- a/tests/test_datalocker_close_resets_instance.py
+++ b/tests/test_datalocker_close_resets_instance.py
@@ -7,6 +7,7 @@ def _patch_seeding(monkeypatch):
     monkeypatch.setattr(DataLocker, "_seed_modifiers_if_empty", lambda self: None)
     monkeypatch.setattr(DataLocker, "_seed_wallets_if_empty", lambda self: None)
     monkeypatch.setattr(DataLocker, "_seed_thresholds_if_empty", lambda self: None)
+    monkeypatch.setattr(DataLocker, "_seed_alerts_if_empty", lambda self: None)
 
 
 def test_close_resets_singleton(tmp_path, monkeypatch):

--- a/tests/test_db_portfolio_alert_toggle.py
+++ b/tests/test_db_portfolio_alert_toggle.py
@@ -53,6 +53,7 @@ def test_db_portfolio_alert_toggle(tmp_path, monkeypatch):
     monkeypatch.setattr(DataLocker, "_seed_modifiers_if_empty", lambda self: None)
     monkeypatch.setattr(DataLocker, "_seed_wallets_if_empty", lambda self: None)
     monkeypatch.setattr(DataLocker, "_seed_thresholds_if_empty", lambda self: None)
+    monkeypatch.setattr(DataLocker, "_seed_alerts_if_empty", lambda self: None)
 
     db_path = tmp_path / "alerts.db"
     dl = DataLocker(str(db_path))

--- a/tests/test_hedge_core_linking.py
+++ b/tests/test_hedge_core_linking.py
@@ -8,6 +8,7 @@ from hedge_core.hedge_core import HedgeCore
 def dl(monkeypatch):
     # Skip default modifier seeding to keep tests self-contained
     monkeypatch.setattr(DataLocker, "_seed_modifiers_if_empty", lambda self: None)
+    monkeypatch.setattr(DataLocker, "_seed_alerts_if_empty", lambda self: None)
     locker = DataLocker(":memory:")
     yield locker
     locker.db.close()

--- a/tests/test_hedge_core_unlink.py
+++ b/tests/test_hedge_core_unlink.py
@@ -7,6 +7,7 @@ from hedge_core.hedge_core import HedgeCore
 @pytest.fixture
 def dl(monkeypatch):
     monkeypatch.setattr(DataLocker, "_seed_modifiers_if_empty", lambda self: None)
+    monkeypatch.setattr(DataLocker, "_seed_alerts_if_empty", lambda self: None)
     locker = DataLocker(":memory:")
     yield locker
     locker.db.close()

--- a/tests/test_invalid_data_locker.py
+++ b/tests/test_invalid_data_locker.py
@@ -7,6 +7,7 @@ def test_data_locker_handles_invalid_path(monkeypatch):
     monkeypatch.setattr(DataLocker, "_seed_modifiers_if_empty", lambda self: None)
     monkeypatch.setattr(DataLocker, "_seed_wallets_if_empty", lambda self: None)
     monkeypatch.setattr(DataLocker, "_seed_thresholds_if_empty", lambda self: None)
+    monkeypatch.setattr(DataLocker, "_seed_alerts_if_empty", lambda self: None)
 
     path = "/dev/null/test.db"  # invalid directory
     try:

--- a/tests/test_launch_pad_recover.py
+++ b/tests/test_launch_pad_recover.py
@@ -49,6 +49,9 @@ def test_operations_menu_recover(monkeypatch):
         def _seed_thresholds_if_empty(self):
             pass
 
+        def _seed_alerts_if_empty(self):
+            pass
+
         def close(self):
             pass
 

--- a/tests/test_modifiers_loading.py
+++ b/tests/test_modifiers_loading.py
@@ -7,6 +7,7 @@ from calc_core.calculation_core import CalculationCore
 @pytest.fixture
 def dl(monkeypatch):
     monkeypatch.setattr(DataLocker, "_seed_modifiers_if_empty", lambda self: None)
+    monkeypatch.setattr(DataLocker, "_seed_alerts_if_empty", lambda self: None)
     locker = DataLocker(":memory:")
     yield locker
     locker.db.close()

--- a/tests/test_position_core_crud.py
+++ b/tests/test_position_core_crud.py
@@ -7,6 +7,7 @@ def _patch_seeding(monkeypatch):
     monkeypatch.setattr(DataLocker, "_seed_modifiers_if_empty", lambda self: None)
     monkeypatch.setattr(DataLocker, "_seed_wallets_if_empty", lambda self: None)
     monkeypatch.setattr(DataLocker, "_seed_thresholds_if_empty", lambda self: None)
+    monkeypatch.setattr(DataLocker, "_seed_alerts_if_empty", lambda self: None)
 
 
 def build_pos(id="p1"):

--- a/tests/test_position_core_e2e.py
+++ b/tests/test_position_core_e2e.py
@@ -38,6 +38,7 @@ def dl(tmp_path, monkeypatch):
         "_seed_modifiers_if_empty",
         "_seed_wallets_if_empty",
         "_seed_thresholds_if_empty",
+        "_seed_alerts_if_empty",
     ]:
         monkeypatch.setattr(DataLocker, name, lambda self: None)
     db_file = tmp_path / "test.db"

--- a/tests/test_position_core_enrich.py
+++ b/tests/test_position_core_enrich.py
@@ -10,6 +10,7 @@ async def test_enrich_positions_returns_enriched_list(tmp_path, monkeypatch):
     monkeypatch.setattr(DataLocker, "_seed_modifiers_if_empty", lambda self: None)
     monkeypatch.setattr(DataLocker, "_seed_wallets_if_empty", lambda self: None)
     monkeypatch.setattr(DataLocker, "_seed_thresholds_if_empty", lambda self: None)
+    monkeypatch.setattr(DataLocker, "_seed_alerts_if_empty", lambda self: None)
 
     db_path = tmp_path / "positions.db"
     dl = DataLocker(str(db_path))

--- a/tests/test_position_sync_service.py
+++ b/tests/test_position_sync_service.py
@@ -34,6 +34,7 @@ def setup_datalocker(tmp_path, monkeypatch):
     monkeypatch.setattr(DataLocker, "_seed_modifiers_if_empty", lambda self: None)
     monkeypatch.setattr(DataLocker, "_seed_wallets_if_empty", lambda self: None)
     monkeypatch.setattr(DataLocker, "_seed_thresholds_if_empty", lambda self: None)
+    monkeypatch.setattr(DataLocker, "_seed_alerts_if_empty", lambda self: None)
 
     dl = DataLocker(str(tmp_path / "sync.db"))
     wallet = {"name": "TestWallet", "public_address": "ADDR1", "private_address": "priv"}

--- a/tests/test_startup_service_wallet.py
+++ b/tests/test_startup_service_wallet.py
@@ -13,6 +13,7 @@ def disable_seeding(monkeypatch):
     monkeypatch.setattr(DataLocker, "_seed_modifiers_if_empty", lambda self: None)
     monkeypatch.setattr(DataLocker, "_seed_wallets_if_empty", lambda self: None)
     monkeypatch.setattr(DataLocker, "_seed_thresholds_if_empty", lambda self: None)
+    monkeypatch.setattr(DataLocker, "_seed_alerts_if_empty", lambda self: None)
 
 
 def test_startup_fails_without_wallet(tmp_path, monkeypatch):

--- a/tests/test_system_vars_default.py
+++ b/tests/test_system_vars_default.py
@@ -6,6 +6,7 @@ def disable_seeding(monkeypatch):
     monkeypatch.setattr(DataLocker, "_seed_modifiers_if_empty", lambda self: None)
     monkeypatch.setattr(DataLocker, "_seed_wallets_if_empty", lambda self: None)
     monkeypatch.setattr(DataLocker, "_seed_thresholds_if_empty", lambda self: None)
+    monkeypatch.setattr(DataLocker, "_seed_alerts_if_empty", lambda self: None)
 
 
 def test_system_vars_default_row_main(tmp_path, monkeypatch):

--- a/tests/test_threshold_import.py
+++ b/tests/test_threshold_import.py
@@ -9,6 +9,7 @@ def setup_dl(tmp_path, monkeypatch):
     monkeypatch.setattr(DataLocker, "_seed_modifiers_if_empty", lambda self: None)
     monkeypatch.setattr(DataLocker, "_seed_wallets_if_empty", lambda self: None)
     monkeypatch.setattr(DataLocker, "_seed_thresholds_if_empty", lambda self: None)
+    monkeypatch.setattr(DataLocker, "_seed_alerts_if_empty", lambda self: None)
     dl = DataLocker(str(tmp_path / "thr.db"))
     return dl
 


### PR DESCRIPTION
## Summary
- auto-load sample alerts from `config/sample_alerts.json` when the alerts table is empty
- document alert seeding behaviour in README
- patch tests to disable the new alert seeding during unit tests

## Testing
- `pytest -q`