### PR TITLE
Patch tests to disable alerts seeding

### DIFF
--- a/tests/test_active_totals.py
+++ b/tests/test_active_totals.py
@@ -4,7 +4,8 @@ from data.data_locker import DataLocker
 from calc_core.calc_services import CalcServices
 
 
-def test_totals_exclude_inactive(tmp_path):
+def test_totals_exclude_inactive(tmp_path, monkeypatch):
+    monkeypatch.setattr(DataLocker, "_seed_alerts_if_empty", lambda self: None, raising=False)
     db_path = tmp_path / "test.db"
     dl = DataLocker(str(db_path))
     core = PositionCore(dl)

--- a/tests/test_alert_core_create_all.py
+++ b/tests/test_alert_core_create_all.py
@@ -8,6 +8,7 @@ def test_create_all_alerts_runs(tmp_path, monkeypatch):
     monkeypatch.setattr(DataLocker, "_seed_modifiers_if_empty", lambda self: None)
     monkeypatch.setattr(DataLocker, "_seed_wallets_if_empty", lambda self: None)
     monkeypatch.setattr(DataLocker, "_seed_thresholds_if_empty", lambda self: None)
+    monkeypatch.setattr(DataLocker, "_seed_alerts_if_empty", lambda self: None, raising=False)
 
     dl = DataLocker(str(tmp_path / "core.db"))
     core = AlertCore(dl)

--- a/tests/test_alert_creation_configurebility.py
+++ b/tests/test_alert_creation_configurebility.py
@@ -59,7 +59,8 @@ def _disabled_config():
     }
 
 
-def test_alert_creation_configurebility(tmp_path):
+def test_alert_creation_configurebility(tmp_path, monkeypatch):
+    monkeypatch.setattr(DataLocker, "_seed_alerts_if_empty", lambda self: None, raising=False)
     db_path = tmp_path / "enabled.db"
     dl = DataLocker(str(db_path))
     _insert_position(dl)

--- a/tests/test_alert_disabled_creation.py
+++ b/tests/test_alert_disabled_creation.py
@@ -19,7 +19,8 @@ def _insert_position(dl):
     dl.positions.insert_position(pos)
 
 
-def test_position_alert_respects_disabled(tmp_path):
+def test_position_alert_respects_disabled(tmp_path, monkeypatch):
+    monkeypatch.setattr(DataLocker, "_seed_alerts_if_empty", lambda self: None, raising=False)
     db_path = tmp_path / "alerts.db"
     dl = DataLocker(str(db_path))
     _insert_position(dl)
@@ -43,7 +44,8 @@ def test_position_alert_respects_disabled(tmp_path):
     assert types == {"TravelPercentLiquid"}
 
 
-def test_portfolio_alert_respects_disabled(tmp_path):
+def test_portfolio_alert_respects_disabled(tmp_path, monkeypatch):
+    monkeypatch.setattr(DataLocker, "_seed_alerts_if_empty", lambda self: None, raising=False)
     db_path = tmp_path / "alerts2.db"
     dl = DataLocker(str(db_path))
 
@@ -65,7 +67,8 @@ def test_portfolio_alert_respects_disabled(tmp_path):
     assert types == {"TotalSize"}
 
 
-def test_disabled_string_values(tmp_path):
+def test_disabled_string_values(tmp_path, monkeypatch):
+    monkeypatch.setattr(DataLocker, "_seed_alerts_if_empty", lambda self: None, raising=False)
     db_path = tmp_path / "alerts3.db"
     dl = DataLocker(str(db_path))
     _insert_position(dl)

--- a/tests/test_alerts_api.py
+++ b/tests/test_alerts_api.py
@@ -15,6 +15,7 @@ def client(tmp_path, monkeypatch):
     monkeypatch.setattr(DataLocker, "_seed_modifiers_if_empty", lambda self: None)
     monkeypatch.setattr(DataLocker, "_seed_wallets_if_empty", lambda self: None)
     monkeypatch.setattr(DataLocker, "_seed_thresholds_if_empty", lambda self: None)
+    monkeypatch.setattr(DataLocker, "_seed_alerts_if_empty", lambda self: None, raising=False)
 
     dl = DataLocker(str(tmp_path / "alerts.db"))
 

--- a/tests/test_database_recovery.py
+++ b/tests/test_database_recovery.py
@@ -8,6 +8,7 @@ from data.data_locker import DataLocker
 def test_recover_malformed_db(tmp_path, monkeypatch):
     monkeypatch.setattr(DataLocker, "_seed_modifiers_if_empty", lambda self: None)
     monkeypatch.setattr(DataLocker, "_seed_wallets_if_empty", lambda self: None)
+    monkeypatch.setattr(DataLocker, "_seed_alerts_if_empty", lambda self: None, raising=False)
 
     db_path = tmp_path / "test.db"
     dl = DataLocker(str(db_path))

--- a/tests/test_db_portfolio_alert_toggle.py
+++ b/tests/test_db_portfolio_alert_toggle.py
@@ -53,6 +53,7 @@ def test_db_portfolio_alert_toggle(tmp_path, monkeypatch):
     monkeypatch.setattr(DataLocker, "_seed_modifiers_if_empty", lambda self: None)
     monkeypatch.setattr(DataLocker, "_seed_wallets_if_empty", lambda self: None)
     monkeypatch.setattr(DataLocker, "_seed_thresholds_if_empty", lambda self: None)
+    monkeypatch.setattr(DataLocker, "_seed_alerts_if_empty", lambda self: None, raising=False)
 
     db_path = tmp_path / "alerts.db"
     dl = DataLocker(str(db_path))

--- a/tests/test_hedge_core_linking.py
+++ b/tests/test_hedge_core_linking.py
@@ -8,6 +8,7 @@ from hedge_core.hedge_core import HedgeCore
 def dl(monkeypatch):
     # Skip default modifier seeding to keep tests self-contained
     monkeypatch.setattr(DataLocker, "_seed_modifiers_if_empty", lambda self: None)
+    monkeypatch.setattr(DataLocker, "_seed_alerts_if_empty", lambda self: None, raising=False)
     locker = DataLocker(":memory:")
     yield locker
     locker.db.close()

--- a/tests/test_hedge_core_unlink.py
+++ b/tests/test_hedge_core_unlink.py
@@ -7,6 +7,7 @@ from hedge_core.hedge_core import HedgeCore
 @pytest.fixture
 def dl(monkeypatch):
     monkeypatch.setattr(DataLocker, "_seed_modifiers_if_empty", lambda self: None)
+    monkeypatch.setattr(DataLocker, "_seed_alerts_if_empty", lambda self: None, raising=False)
     locker = DataLocker(":memory:")
     yield locker
     locker.db.close()

--- a/tests/test_invalid_data_locker.py
+++ b/tests/test_invalid_data_locker.py
@@ -7,6 +7,7 @@ def test_data_locker_handles_invalid_path(monkeypatch):
     monkeypatch.setattr(DataLocker, "_seed_modifiers_if_empty", lambda self: None)
     monkeypatch.setattr(DataLocker, "_seed_wallets_if_empty", lambda self: None)
     monkeypatch.setattr(DataLocker, "_seed_thresholds_if_empty", lambda self: None)
+    monkeypatch.setattr(DataLocker, "_seed_alerts_if_empty", lambda self: None, raising=False)
 
     path = "/dev/null/test.db"  # invalid directory
     try:

--- a/tests/test_modifiers_loading.py
+++ b/tests/test_modifiers_loading.py
@@ -7,6 +7,7 @@ from calc_core.calculation_core import CalculationCore
 @pytest.fixture
 def dl(monkeypatch):
     monkeypatch.setattr(DataLocker, "_seed_modifiers_if_empty", lambda self: None)
+    monkeypatch.setattr(DataLocker, "_seed_alerts_if_empty", lambda self: None, raising=False)
     locker = DataLocker(":memory:")
     yield locker
     locker.db.close()

--- a/tests/test_position_core_crud.py
+++ b/tests/test_position_core_crud.py
@@ -7,6 +7,7 @@ def _patch_seeding(monkeypatch):
     monkeypatch.setattr(DataLocker, "_seed_modifiers_if_empty", lambda self: None)
     monkeypatch.setattr(DataLocker, "_seed_wallets_if_empty", lambda self: None)
     monkeypatch.setattr(DataLocker, "_seed_thresholds_if_empty", lambda self: None)
+    monkeypatch.setattr(DataLocker, "_seed_alerts_if_empty", lambda self: None, raising=False)
 
 
 def build_pos(id="p1"):

--- a/tests/test_position_core_e2e.py
+++ b/tests/test_position_core_e2e.py
@@ -38,8 +38,9 @@ def dl(tmp_path, monkeypatch):
         "_seed_modifiers_if_empty",
         "_seed_wallets_if_empty",
         "_seed_thresholds_if_empty",
+        "_seed_alerts_if_empty",
     ]:
-        monkeypatch.setattr(DataLocker, name, lambda self: None)
+        monkeypatch.setattr(DataLocker, name, lambda self: None, raising=False)
     db_file = tmp_path / "test.db"
     locker = DataLocker(str(db_file))
     yield locker

--- a/tests/test_position_core_enrich.py
+++ b/tests/test_position_core_enrich.py
@@ -10,6 +10,7 @@ async def test_enrich_positions_returns_enriched_list(tmp_path, monkeypatch):
     monkeypatch.setattr(DataLocker, "_seed_modifiers_if_empty", lambda self: None)
     monkeypatch.setattr(DataLocker, "_seed_wallets_if_empty", lambda self: None)
     monkeypatch.setattr(DataLocker, "_seed_thresholds_if_empty", lambda self: None)
+    monkeypatch.setattr(DataLocker, "_seed_alerts_if_empty", lambda self: None, raising=False)
 
     db_path = tmp_path / "positions.db"
     dl = DataLocker(str(db_path))

--- a/tests/test_position_sync_service.py
+++ b/tests/test_position_sync_service.py
@@ -34,6 +34,7 @@ def setup_datalocker(tmp_path, monkeypatch):
     monkeypatch.setattr(DataLocker, "_seed_modifiers_if_empty", lambda self: None)
     monkeypatch.setattr(DataLocker, "_seed_wallets_if_empty", lambda self: None)
     monkeypatch.setattr(DataLocker, "_seed_thresholds_if_empty", lambda self: None)
+    monkeypatch.setattr(DataLocker, "_seed_alerts_if_empty", lambda self: None, raising=False)
 
     dl = DataLocker(str(tmp_path / "sync.db"))
     wallet = {"name": "TestWallet", "public_address": "ADDR1", "private_address": "priv"}

--- a/tests/test_startup_service_wallet.py
+++ b/tests/test_startup_service_wallet.py
@@ -13,6 +13,7 @@ def disable_seeding(monkeypatch):
     monkeypatch.setattr(DataLocker, "_seed_modifiers_if_empty", lambda self: None)
     monkeypatch.setattr(DataLocker, "_seed_wallets_if_empty", lambda self: None)
     monkeypatch.setattr(DataLocker, "_seed_thresholds_if_empty", lambda self: None)
+    monkeypatch.setattr(DataLocker, "_seed_alerts_if_empty", lambda self: None, raising=False)
 
 
 def test_startup_fails_without_wallet(tmp_path, monkeypatch):

--- a/tests/test_system_vars_default.py
+++ b/tests/test_system_vars_default.py
@@ -6,6 +6,7 @@ def disable_seeding(monkeypatch):
     monkeypatch.setattr(DataLocker, "_seed_modifiers_if_empty", lambda self: None)
     monkeypatch.setattr(DataLocker, "_seed_wallets_if_empty", lambda self: None)
     monkeypatch.setattr(DataLocker, "_seed_thresholds_if_empty", lambda self: None)
+    monkeypatch.setattr(DataLocker, "_seed_alerts_if_empty", lambda self: None, raising=False)
 
 
 def test_system_vars_default_row_main(tmp_path, monkeypatch):

--- a/tests/test_threshold_import.py
+++ b/tests/test_threshold_import.py
@@ -9,6 +9,7 @@ def setup_dl(tmp_path, monkeypatch):
     monkeypatch.setattr(DataLocker, "_seed_modifiers_if_empty", lambda self: None)
     monkeypatch.setattr(DataLocker, "_seed_wallets_if_empty", lambda self: None)
     monkeypatch.setattr(DataLocker, "_seed_thresholds_if_empty", lambda self: None)
+    monkeypatch.setattr(DataLocker, "_seed_alerts_if_empty", lambda self: None, raising=False)
     dl = DataLocker(str(tmp_path / "thr.db"))
     return dl
 


### PR DESCRIPTION
## Summary
- prevent DataLocker alert seeding in tests by monkeypatching `_seed_alerts_if_empty`

## Testing
- `pytest -q`