### PR TITLE
Add source field to alert thresholds

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,7 +205,10 @@ Use the **Export** button on the Alert Thresholds page (or the
 `/system/alert_thresholds/export` API endpoint) to save a JSON snapshot of the
 current threshold limits to the `/config/alert_thresholds.json` file on the
 server. These exported values are the limits the system uses when evaluating
-alerts—they do **not** represent the current alerts themselves.
+alerts—they do **not** represent the current alerts themselves. The exported
+file now includes a top-level `source` field set to `"db"` when generated from
+the database. A file created by `StartUpService.ensure_alert_thresholds()` will
+set `"source": "fallback"`.
 
 ## Running `sonic_app.py`
 

--- a/tests/test_startup_service_alert_thresholds.py
+++ b/tests/test_startup_service_alert_thresholds.py
@@ -36,3 +36,20 @@ def test_ensure_alert_thresholds_valid(tmp_path, monkeypatch):
 
     ss.StartUpService.ensure_alert_thresholds()
 
+
+def test_ensure_alert_thresholds_creates_default_with_source(tmp_path, monkeypatch):
+    default_file = tmp_path / "alert_thresholds.json"
+
+    importlib.reload(ss)
+    monkeypatch.setattr(ss, "ALERT_THRESHOLDS_PATH", default_file)
+    import utils.config_loader as cfg
+    monkeypatch.setattr(cfg, "ALERT_THRESHOLDS_PATH", default_file)
+    monkeypatch.setattr(SchemaValidationService, "ALERT_THRESHOLDS_FILE", str(default_file))
+
+    ss.StartUpService.ensure_alert_thresholds()
+
+    with open(default_file, "r", encoding="utf-8") as f:
+        data = json.load(f)
+
+    assert data.get("source") == "fallback"
+

--- a/tests/test_threshold_import.py
+++ b/tests/test_threshold_import.py
@@ -71,15 +71,16 @@ def test_changes_export_to_json(tmp_path, monkeypatch):
 
     with open(json_path, "r", encoding="utf-8") as f:
         data = json.load(f)
-    assert len(data) == 1
-    assert data[0]["id"] == "t1"
+    assert data["source"] == "db"
+    assert len(data["thresholds"]) == 1
+    assert data["thresholds"][0]["id"] == "t1"
 
     mgr.update("t1", {"low": 5})
     with open(json_path, "r", encoding="utf-8") as f:
         data = json.load(f)
-    assert data[0]["low"] == 5
+    assert data["thresholds"][0]["low"] == 5
 
     mgr.delete("t1")
     with open(json_path, "r", encoding="utf-8") as f:
         data = json.load(f)
-    assert data == []
+    assert data["thresholds"] == []

--- a/utils/schema_validation_service.py
+++ b/utils/schema_validation_service.py
@@ -19,6 +19,7 @@ class SchemaValidationService:
     ALERT_THRESHOLDS_SCHEMA = {
         "type": "object",
         "properties": {
+            "source": {"type": "string"},
             "alert_ranges": {
                 "type": "object",
                 "properties": {

--- a/utils/startup_service.py
+++ b/utils/startup_service.py
@@ -164,6 +164,7 @@ class StartUpService:
         if not os.path.exists(ALERT_THRESHOLDS_PATH):
             log.warning("⚠️ alert_thresholds.json not found. Creating default template...")
             default = {
+                "source": "fallback",
                 "alert_ranges": {},
                 "global_alert_config": {
                     "enabled": True,


### PR DESCRIPTION
## Summary
- track configuration origin via new `source` field
- set `source: fallback` when StartUpService creates default template
- include `source: db` when exporting thresholds from the database
- support new schema for import/export
- test new behaviour and document the change

## Testing
- `pytest -q`