### PR TITLE
Add header comment to phantom manager

### DIFF
--- a/auto_core/phantom_manager.py
+++ b/auto_core/phantom_manager.py
@@ -1,3 +1,11 @@
+# =============================================================================
+# 🦄 PhantomManager
+# -----------------------------------------------------------------------------
+# Playwright-based automation helper for the Phantom browser extension.  This
+# module launches a Chromium browser with Phantom loaded, provides utilities for
+# unlocking the wallet, approving transactions and handling onboarding flows.
+# =============================================================================
+
 import logging
 import os
 from typing import List, Optional


### PR DESCRIPTION
## Summary
- add a brief stylish header to `PhantomManager`

## Testing
- `pytest -q` *(fails: ImportError phantom_workflow, AttributeError open_extension_popup)*